### PR TITLE
[LTM-33] 당첨 정보 상세 회차 선택 피커 View 수정

### DIFF
--- a/.idea/deploymentTargetSelector.xml
+++ b/.idea/deploymentTargetSelector.xml
@@ -19,6 +19,9 @@
       <SelectionState runConfigName="LottoInfoScreenPreview">
         <option name="selectionMode" value="DROPDOWN" />
       </SelectionState>
+      <SelectionState runConfigName="LottoRoundWheelPickerContentPreview">
+        <option name="selectionMode" value="DROPDOWN" />
+      </SelectionState>
     </selectionStates>
   </component>
 </project>

--- a/app/src/main/java/com/lottomate/lottomate/presentation/screen/lottoinfo/LottoInfoScreen.kt
+++ b/app/src/main/java/com/lottomate/lottomate/presentation/screen/lottoinfo/LottoInfoScreen.kt
@@ -189,6 +189,8 @@ private fun LottoInfoContent(
                 onClickSelect = onChangeLottoRound,
             )
         },
+        sheetDragHandle = null,
+        sheetSwipeEnabled = false,
         snackbarHost = { SnackbarHost(hostState = scaffoldState.snackbarHostState) }
     ) { innerPadding ->
         Box(

--- a/app/src/main/java/com/lottomate/lottomate/presentation/screen/lottoinfo/LottoInfoScreen.kt
+++ b/app/src/main/java/com/lottomate/lottomate/presentation/screen/lottoinfo/LottoInfoScreen.kt
@@ -17,20 +17,14 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.rounded.KeyboardArrowLeft
-import androidx.compose.material.icons.rounded.KeyboardArrowRight
 import androidx.compose.material3.BottomSheetScaffold
 import androidx.compose.material3.BottomSheetScaffoldState
-import androidx.compose.material3.CenterAlignedTopAppBar
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.SheetValue
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.Text
-import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.material3.rememberBottomSheetScaffoldState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -47,7 +41,6 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringArrayResource
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -70,7 +63,6 @@ import com.lottomate.lottomate.presentation.ui.LottoMateBlue5
 import com.lottomate.lottomate.presentation.ui.LottoMateGray120
 import com.lottomate.lottomate.presentation.ui.LottoMateGray40
 import com.lottomate.lottomate.presentation.ui.LottoMateGray70
-import com.lottomate.lottomate.presentation.ui.LottoMateTheme
 import com.lottomate.lottomate.presentation.ui.LottoMateWhite
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch

--- a/app/src/main/java/com/lottomate/lottomate/presentation/screen/lottoinfo/LottoInfoScreen.kt
+++ b/app/src/main/java/com/lottomate/lottomate/presentation/screen/lottoinfo/LottoInfoScreen.kt
@@ -2,6 +2,7 @@ package com.lottomate.lottomate.presentation.screen.lottoinfo
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -354,9 +355,11 @@ private fun LottoRoundSection(
         )
 
         Row(
-            modifier = Modifier.clickable {
-                onClickCurrentRound()
-            },
+            modifier = Modifier.clickable(
+                interactionSource = remember { MutableInteractionSource() },
+                indication = null,
+                onClick = onClickCurrentRound,
+            ),
             verticalAlignment = Alignment.CenterVertically,
             horizontalArrangement = Arrangement.Center,
         ) {

--- a/app/src/main/java/com/lottomate/lottomate/presentation/screen/lottoinfo/LottoInfoScreen.kt
+++ b/app/src/main/java/com/lottomate/lottomate/presentation/screen/lottoinfo/LottoInfoScreen.kt
@@ -27,12 +27,14 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.SheetValue
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.material3.rememberBottomSheetScaffoldState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -173,6 +175,11 @@ private fun LottoInfoContent(
     onClickBottomBanner: () -> Unit,
 ) {
     val coroutineScope = rememberCoroutineScope()
+    val isDimVisible by remember {
+        derivedStateOf {
+            scaffoldState.bottomSheetState.targetValue == SheetValue.Expanded
+        }
+    }
 
     BottomSheetScaffold(
         modifier = modifier.fillMaxSize(),
@@ -281,6 +288,16 @@ private fun LottoInfoContent(
                 titleRes = R.string.top_app_bar_title_lotto_info,
                 hasNavigation = true,
                 onBackPressed = onBackPressed,
+            )
+
+            BottomSheetDimBackground(
+                modifier = Modifier.fillMaxSize(),
+                isDimVisible = isDimVisible,
+                onClick = {
+                    coroutineScope.launch {
+                        scaffoldState.bottomSheetState.partialExpand()
+                    }
+                }
             )
         }
     }
@@ -521,6 +538,21 @@ private fun BottomBannerSection(
                 color = LottoMateGray120
             )
         }
+    }
+}
+
+@Composable
+private fun BottomSheetDimBackground(
+    modifier: Modifier = Modifier,
+    isDimVisible: Boolean,
+    onClick: () -> Unit,
+) {
+    if (isDimVisible) {
+        Box(
+            modifier = modifier
+                .background(LottoMateBlack.copy(0.4f))
+                .clickable { onClick() }
+        )
     }
 }
 

--- a/app/src/main/java/com/lottomate/lottomate/presentation/screen/lottoinfo/LottoInfoScreen.kt
+++ b/app/src/main/java/com/lottomate/lottomate/presentation/screen/lottoinfo/LottoInfoScreen.kt
@@ -191,6 +191,12 @@ private fun LottoInfoContent(
         },
         sheetDragHandle = null,
         sheetSwipeEnabled = false,
+        sheetShape = RoundedCornerShape(
+            topStart = 32.dp,
+            topEnd = 32.dp,
+            bottomStart = 0.dp,
+            bottomEnd = 0.dp
+        ),
         snackbarHost = { SnackbarHost(hostState = scaffoldState.snackbarHostState) }
     ) { innerPadding ->
         Box(

--- a/app/src/main/java/com/lottomate/lottomate/presentation/screen/lottoinfo/component/LottoRoundWheelPicker.kt
+++ b/app/src/main/java/com/lottomate/lottomate/presentation/screen/lottoinfo/component/LottoRoundWheelPicker.kt
@@ -4,18 +4,24 @@ import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
 import androidx.compose.foundation.gestures.FlingBehavior
 import androidx.compose.foundation.gestures.snapping.rememberSnapFlingBehavior
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material3.BottomSheetScaffoldState
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
+import androidx.compose.material3.rememberBottomSheetScaffoldState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -26,23 +32,25 @@ import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.drawWithContent
-import androidx.compose.ui.graphics.BlendMode
-import androidx.compose.ui.graphics.Brush
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.CompositingStrategy
-import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.lottomate.lottomate.presentation.component.LottoMateAssistiveButton
 import com.lottomate.lottomate.presentation.component.LottoMateButtonProperty
 import com.lottomate.lottomate.presentation.component.LottoMateSolidButton
 import com.lottomate.lottomate.presentation.screen.lottoinfo.LottoRoundViewModel
 import com.lottomate.lottomate.presentation.screen.lottoinfo.PickerState
+import com.lottomate.lottomate.presentation.screen.lottoinfo.rememberPickerState
+import com.lottomate.lottomate.presentation.ui.LottoMateBlack
+import com.lottomate.lottomate.presentation.ui.LottoMateGray90
+import com.lottomate.lottomate.presentation.ui.LottoMateRed5
+import com.lottomate.lottomate.presentation.ui.LottoMateTheme
 import com.lottomate.lottomate.presentation.ui.LottoMateWhite
 import com.lottomate.lottomate.utils.DateUtils.calLottoRoundDate
 import kotlinx.coroutines.flow.distinctUntilChanged
@@ -95,6 +103,7 @@ fun LottoRoundWheelPicker(
         lastDate = lastDate,
         visibleItemCount = visibleItemCount,
         lottoRoundRange = lottoRoundRange,
+        currentIndex = lottoRoundRange.indexOf(pickerState.selectedItem),
         scaffoldState = scaffoldState,
         scrollState = scrollState,
         flingBehavior = flingBehavior,
@@ -109,6 +118,8 @@ private fun LottoRoundWheelPickerContent(
     lastDate: String,
     visibleItemCount: Int,
     lottoRoundRange: List<String>,
+    currentIndex: Int,
+    pickerMaxHeight: Dp = 116.dp,
     scaffoldState: BottomSheetScaffoldState,
     scrollState: LazyListState,
     flingBehavior: FlingBehavior,
@@ -119,18 +130,26 @@ private fun LottoRoundWheelPickerContent(
     var itemHeightPixel by remember { mutableIntStateOf(0) }
     val itemHeightToDp = pixelsToDp(pixels = itemHeightPixel)
 
-    val fadingEdgeGradient = remember {
-        Brush.verticalGradient(
-            0f to Color.Transparent,
-            0.5f to Color.Black,
-            1f to Color.Transparent
-        )
-    }
-
     Column(modifier = modifier.background(LottoMateWhite)) {
         Spacer(modifier = Modifier.height(32.dp))
 
-        Box(modifier = modifier) {
+        Text(
+            text = "회차 선택",
+            style = MaterialTheme.typography.headlineLarge,
+            modifier = Modifier.padding(start = 20.dp),
+        )
+
+        Spacer(modifier = Modifier.height((23.372).dp))
+
+        Box(modifier = Modifier.fillMaxWidth()) {
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .offset(y = itemHeightToDp - (40.dp - itemHeightToDp) / 2)
+                    .background(LottoMateRed5)
+                    .height(40.dp)
+            )
+
             LazyColumn(
                 state = scrollState,
                 flingBehavior = flingBehavior,
@@ -138,57 +157,97 @@ private fun LottoRoundWheelPickerContent(
                 modifier = Modifier
                     .fillMaxWidth()
                     .height(itemHeightToDp * visibleItemCount)
-                    .fadingEdge(fadingEdgeGradient)
             ) {
                 items(lottoRoundRange.size) { index ->
-                    Text(
-                        text = if (index == 0) {
-                            lottoRoundRange[index]
-                        } else {
-                            lottoRoundRange[index]
-                                .plus("회")
-                                .plus(" (")
-                                .plus(calLottoRoundDate(lastDate, index))
-                                .plus(")")
-                        },
-                        textAlign = TextAlign.Center,
-                        maxLines = 1,
-                        overflow = TextOverflow.Ellipsis,
+                    Row(
                         modifier = Modifier
-                            .onSizeChanged { size -> itemHeightPixel = size.height }
-                            .padding(vertical = 4.dp)
-                    )
+                            .fillMaxWidth()
+                            .height(pickerMaxHeight * 0.333f)
+                            .padding(horizontal = 20.dp)
+                            .onSizeChanged { size -> itemHeightPixel = size.height },
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.Center,
+                    ) {
+                        Text(
+                            text = if (index == 0) lottoRoundRange[index] else lottoRoundRange[index].plus("회"),
+                            textAlign = TextAlign.Center,
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis,
+                            style = MaterialTheme.typography.headlineLarge
+                                .copy(if (currentIndex == index) LottoMateBlack else LottoMateGray90),
+                        )
+
+                        Spacer(modifier = Modifier.width(20.dp))
+
+                        Text(
+                            text = if (index == 0) "" else calLottoRoundDate(lastDate, index),
+                            style = MaterialTheme.typography.bodyLarge
+                                .copy(if (currentIndex == index) LottoMateBlack else LottoMateGray90),
+                        )
+                    }
                 }
             }
         }
 
-        Spacer(modifier = Modifier.height(32.dp))
+        Spacer(modifier = Modifier.height((23.372).dp))
 
-        LottoMateSolidButton(
-            text = "선택",
-            buttonSize = LottoMateButtonProperty.Size.LARGE,
+        Row(
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(horizontal = 16.dp),
-            onClick = {
-                onClickSelect()
+                .padding(horizontal = 20.dp),
+        ) {
+            LottoMateAssistiveButton(
+                text = "취소",
+                buttonSize = LottoMateButtonProperty.Size.LARGE,
+                onClick = {
+                    coroutineScope.launch {
+                        scaffoldState.bottomSheetState.partialExpand()
+                    }
+                },
+                modifier = Modifier.weight(1f),
+            )
 
-                coroutineScope.launch {
-                    scaffoldState.bottomSheetState.partialExpand()
+            Spacer(modifier = Modifier.width(15.dp))
+
+            LottoMateSolidButton(
+                text = "확인",
+                buttonSize = LottoMateButtonProperty.Size.LARGE,
+                modifier = Modifier.weight(1f),
+                onClick = {
+                    onClickSelect()
+
+                    coroutineScope.launch {
+                        scaffoldState.bottomSheetState.partialExpand()
+                    }
                 }
-            }
-        )
+            )
+        }
 
-        Spacer(modifier = Modifier.height(16.dp))
+        Spacer(modifier = Modifier.height(28.dp))
     }
 }
 
-private fun Modifier.fadingEdge(brush: Brush) = this
-    .graphicsLayer(compositingStrategy = CompositingStrategy.Offscreen)
-    .drawWithContent {
-        drawContent()
-        drawRect(brush = brush, blendMode = BlendMode.DstIn)
-    }
-
 @Composable
 private fun pixelsToDp(pixels: Int) = with(LocalDensity.current) { pixels.toDp() }
+
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalFoundationApi::class)
+@Preview(showBackground = true)
+@Composable
+private fun LottoRoundWheelPickerContentPreview() {
+    LottoMateTheme {
+        val scrollState = rememberLazyListState()
+        val pickerState = rememberPickerState()
+        val ranges = List(20) { it.toString() }
+
+        LottoRoundWheelPickerContent(
+            lastDate = "2024-03-01",
+            lottoRoundRange = ranges,
+            visibleItemCount = 3,
+            scaffoldState = rememberBottomSheetScaffoldState(),
+            scrollState = scrollState,
+            currentIndex = ranges.indexOf(pickerState.selectedItem),
+            flingBehavior = rememberSnapFlingBehavior(lazyListState = scrollState),
+            onClickSelect = {}
+        )
+    }
+}


### PR DESCRIPTION
## 💡 ISSUE
- #14 

</br>

## 📝 작업 내용
- [x] 로또 회차 선택 시, press 효과 제거
- [x] 로또 회차 선택 피커 View 수정
  - [x] 피커 Title 추가
  - [x] Text Style 적용
  - [x] Item 배경 적용
  - [x] 취소 버튼 추가
- [x] BottomSheet Swipe 비허용 설정 (스와이프하여 종료 비허용)
- [x] BottomSheet Radius 적용
- [x] BottomSheet 활성화되었을 때 Dim Background 적용

</br>

## 📸 ScreenShot (Optional)
|`Before`|`After`|
|:--:|:--:|
|![로또_회차_선택_피커_수정_전1](https://github.com/user-attachments/assets/4275057b-e30e-4eda-abdd-7f5cc450b9ce)|![로또_회차_선택_피커_수정_후1](https://github.com/user-attachments/assets/1d7b6765-533a-4c67-b688-9fecf4e3e97e)|
|![로또_회차_선택_피커_수정_전2](https://github.com/user-attachments/assets/acc9351d-92fa-4c50-a4b4-ceb6ea27155d)|![로또_회차_선택_피커_수정_후2](https://github.com/user-attachments/assets/e3f41cd3-7a84-44dd-81f1-5a67cca15aac)|
