### PR TITLE
[LTM-114] Typography의 LineHeight 보정

### DIFF
--- a/app/src/main/java/com/lottomate/lottomate/presentation/component/Cards.kt
+++ b/app/src/main/java/com/lottomate/lottomate/presentation/component/Cards.kt
@@ -1,5 +1,6 @@
 package com.lottomate.lottomate.presentation.component
 
+import androidx.annotation.DrawableRes
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
@@ -8,11 +9,11 @@ import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardColors
@@ -20,23 +21,51 @@ import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.CardElevation
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.res.imageResource
-import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.lottomate.lottomate.R
+import com.lottomate.lottomate.presentation.navigation.LottoMateRoute
 import com.lottomate.lottomate.presentation.res.Dimens
+import com.lottomate.lottomate.presentation.screen.main.MainBottomTab
 import com.lottomate.lottomate.presentation.ui.LottoMateBlack
-import com.lottomate.lottomate.presentation.ui.LottoMateGray120
+import com.lottomate.lottomate.presentation.ui.LottoMateBlue5
+import com.lottomate.lottomate.presentation.ui.LottoMateGray90
 import com.lottomate.lottomate.presentation.ui.LottoMateTheme
 import com.lottomate.lottomate.presentation.ui.LottoMateWhite
 import com.lottomate.lottomate.presentation.ui.LottoMateYellow5
 import com.lottomate.lottomate.utils.dropShadow
 import com.lottomate.lottomate.utils.noInteractionClickable
+
+enum class BannerType(
+    val title: String = "",
+    val subTitle: String = "",
+    val backgroundColor: Color,
+    @DrawableRes val img: Int,
+    val route: LottoMateRoute,
+) {
+    // 지도
+    MAP(
+        title = "행운의 1등 로또\n어디서 샀을까?",
+        subTitle = "당첨 판매점 보기",
+        backgroundColor = LottoMateYellow5,
+        img = R.drawable.img_banner_map,
+        route = MainBottomTab.MAP.route,
+    ),
+    // 당첨자 가이드
+    WINNER_GUIDE(
+        title = "내가 당첨이 됐다면\n어떻게 해야할까",
+        subTitle = "당첨자 가이드 확인하기",
+        backgroundColor = LottoMateBlue5,
+        img = R.drawable.img_home_slo_cony,
+        route = LottoMateRoute.LottoWinnerGuide,
+    )
+}
 
 @Composable
 fun LottoMateCard(
@@ -73,13 +102,15 @@ fun LottoMateCard(
 @Composable
 fun BannerCard(
     modifier: Modifier = Modifier,
+    type: BannerType = BannerType.WINNER_GUIDE,
     onClickBanner: () -> Unit,
 ) {
     Box(
         modifier = modifier
+            .fillMaxWidth()
             .height(100.dp)
             .background(
-                color = LottoMateYellow5,
+                color = type.backgroundColor,
                 shape = RoundedCornerShape(Dimens.RadiusLarge)
             )
             .clickable(
@@ -88,33 +119,34 @@ fun BannerCard(
                 onClick = onClickBanner
             )
     ) {
-        Row(
-            horizontalArrangement = Arrangement.SpaceBetween,
+        Column(
             modifier = Modifier
-                .fillMaxWidth()
-                .padding(top = 15.dp, start = 20.dp, end = 18.dp),
+                .align(Alignment.CenterStart)
+                .padding(start = 20.dp),
+            verticalArrangement = Arrangement.Center,
         ) {
-            Column {
-                LottoMateText(
-                    text = stringResource(id = R.string.banner_lotto_info_title),
-                    style = LottoMateTheme.typography.headline2,
-                )
+            LottoMateText(
+                text = type.title,
+                style = LottoMateTheme.typography.headline2,
+            )
 
-                Spacer(modifier = Modifier.height(4.dp))
+            Spacer(modifier = Modifier.height(4.dp))
 
-                LottoMateText(
-                    text = stringResource(id = R.string.banner_lotto_info_sub_title),
-                    style = LottoMateTheme.typography.caption
-                        .copy(LottoMateGray120),
-                )
-            }
-
-            Image(
-                bitmap = ImageBitmap.imageResource(id = R.drawable.bn_pochi_lotto_info),
-                contentDescription = "Lotto Info Bottom Banner Image",
-                modifier = Modifier.padding(bottom = 7.dp),
+            LottoMateText(
+                text = type.subTitle,
+                style = LottoMateTheme.typography.caption
+                    .copy(LottoMateGray90),
             )
         }
+
+        Image(
+            bitmap = ImageBitmap.imageResource(id = type.img),
+            contentDescription = "Lotto Info Bottom Banner Image",
+            modifier = Modifier
+                .align(Alignment.BottomEnd)
+                .padding(bottom = 8.dp, end = 24.dp)
+                .size(width = 122.dp, height = 76.dp),
+        )
     }
 }
 
@@ -122,7 +154,9 @@ fun BannerCard(
 @Composable
 private fun BannerCardPreview() {
     LottoMateTheme {
-        BannerCard {
+        BannerCard(
+            type = BannerType.WINNER_GUIDE,
+        ) {
 
         }
     }

--- a/app/src/main/java/com/lottomate/lottomate/presentation/ui/Type.kt
+++ b/app/src/main/java/com/lottomate/lottomate/presentation/ui/Type.kt
@@ -32,94 +32,91 @@ private val pretendardStyle = TextStyle(
 
 private val display1 = pretendardStyle.copy(
     fontWeight = FontWeight.Bold,
-//    fontSize = 52.sp,
     fontSize = 48.sp,
     lineHeight = 62.sp,
 )
 
 private val display2 = pretendardStyle.copy(
     fontWeight = FontWeight.Bold,
-//    fontSize = 42.sp,
     fontSize = 40.sp,
-    lineHeight = 54.sp,
+//    lineHeight = 54.sp,
+    lineHeight = 53.sp,
 )
 
 private val title1 = pretendardStyle.copy(
     fontWeight = FontWeight.Bold,
-//    fontSize = 40.sp,
     fontSize = 36.sp,
     lineHeight = 48.sp,
 )
 
 private val title2 = pretendardStyle.copy(
     fontWeight = FontWeight.Bold,
-//    fontSize = 31.sp,
     fontSize = 28.sp,
-    lineHeight = 40.sp,
+//    lineHeight = 40.sp,
+    lineHeight = 39.sp,
 )
 
 private val title3 = pretendardStyle.copy(
     fontWeight = FontWeight.Bold,
-//    fontSize = 27.sp,
     fontSize = 24.sp,
-    lineHeight = 34.sp,
+//    lineHeight = 34.sp,
+    lineHeight = 32.sp,
 )
 
 private val headline1 = pretendardStyle.copy(
     fontWeight = FontWeight.Bold,
-//    fontSize = 20.sp,
     fontSize = 18.sp,
-    lineHeight = 28.sp,
+//    lineHeight = 28.sp,
+    lineHeight = 25.sp,
 )
 
 private val headline2 = pretendardStyle.copy(
     fontWeight = FontWeight.Bold,
-//    fontSize = 18.sp,
     fontSize = 16.sp,
-//    lineHeight = 26.sp,
-    lineHeight = 24.sp,
+//    lineHeight = 24.sp,
+    lineHeight = 21.sp,
 )
 
 private val body1 = pretendardStyle.copy(
     fontWeight = FontWeight.Medium,
-//    fontSize = 18.sp,
     fontSize = 16.sp,
-    lineHeight = 24.sp,
+//    lineHeight = 24.sp,
+    lineHeight = 20.sp,
 )
 
 private val body2 = pretendardStyle.copy(
     fontWeight = FontWeight.Normal,
-//    fontSize = 18.sp,
     fontSize = 16.sp,
-    lineHeight = 24.sp,
+//    lineHeight = 24.sp,
+    lineHeight = 21.sp,
 )
 
 private val label1 = pretendardStyle.copy(
     fontWeight = FontWeight.Medium,
-//    fontSize = 18.sp,
     fontSize = 14.sp,
-//    lineHeight = 24.sp,
-    lineHeight = 22.sp,
+//    lineHeight = 22.sp,
+    lineHeight = 20.sp,
 )
 
 private val label2 = pretendardStyle.copy(
     fontWeight = FontWeight.SemiBold,
-//    fontSize = 15.sp,
     fontSize = 14.sp,
-    lineHeight = 22.sp,
+//    lineHeight = 22.sp,
+    lineHeight = 20.sp,
 )
 
 private val caption = pretendardStyle.copy(
     fontWeight = FontWeight.SemiBold,
-//    fontSize = 13.sp,
     fontSize = 12.sp,
-    lineHeight = 18.sp,
+//    lineHeight = 18.sp,
+    lineHeight = 16.sp,
 )
 
 private val caption2 = pretendardStyle.copy(
     fontWeight = FontWeight.Medium,
     fontSize = 10.sp,
-    lineHeight = 16.sp,
+//    lineHeight = 16.sp,
+    lineHeight = 14.sp,
 )
 
 @Immutable


### PR DESCRIPTION
## 💡 ISSUE
- #50 

</br>

## 📝 작업 내용
- 각 폰트 레벨의 LineHeight를 피그마와 비교하여 값 수정
- 문제 인식
  - 줄바꿈(\n)된 문장을 보았을 때 줄간격이 피그마 상의 화면과 많이 차이남을 인식
- 해결 과정
  - 각 폰트 레벨에 피그마에 정의된 LineHeight로 설정해주었음에도 **각 폰트 레벨마다 피그마와 안드로이드 실기기에서 비교해보았을 때 LineHeight의 값이 0에서 -4까지 차이가 있음을 확인**

</br>

## 📸 ScreenShot (Optional)
![Frame 1346047998](https://github.com/user-attachments/assets/36b922b8-64d4-472a-915b-e718e1438970)
![Frame 1346047997](https://github.com/user-attachments/assets/2de54995-eab6-41a0-aa38-cf8c2958495f)