### PR TITLE
[LTM-126] 당첨금 수령 장소 네이버 지도 연결

### DIFF
--- a/app/src/main/java/com/lottomate/lottomate/presentation/component/Webviews.kt
+++ b/app/src/main/java/com/lottomate/lottomate/presentation/component/Webviews.kt
@@ -1,7 +1,10 @@
 package com.lottomate.lottomate.presentation.component
 
+import android.webkit.WebChromeClient
+import android.webkit.WebSettings
 import android.webkit.WebView
 import android.webkit.WebViewClient
+import androidx.annotation.StringRes
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
@@ -9,17 +12,16 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.viewinterop.AndroidView
-import com.lottomate.lottomate.R
 import com.lottomate.lottomate.presentation.res.Dimens
-import com.lottomate.lottomate.presentation.ui.LottoMateTheme
 import com.lottomate.lottomate.presentation.ui.LottoMateWhite
-import java.net.URLEncoder
 
 @Composable
-fun LottoMateNaverMapWebView(
-    place: String,
+fun LottoMateBasicWebView(
+    @StringRes title: Int,
+    url: String,
+    webViewClient: WebViewClient = WebViewClient(),
+    webChromeClient: WebChromeClient = WebChromeClient(),
     onBackPressed: () -> Unit,
 ) {
     val context = LocalContext.current
@@ -29,8 +31,6 @@ fun LottoMateNaverMapWebView(
             .fillMaxSize()
             .background(LottoMateWhite),
     ) {
-        val encodedPlace = URLEncoder.encode(place, "UTF-8")
-
         AndroidView(
             modifier = Modifier
                 .padding(top = Dimens.BaseTopPadding)
@@ -45,30 +45,22 @@ fun LottoMateNaverMapWebView(
                     settings.builtInZoomControls = true
                     settings.displayZoomControls = false
 
+                    clearCache(true) // 캐시 제거
+                    clearHistory()   // 기록 제거
+                    settings.cacheMode = WebSettings.LOAD_NO_CACHE // 캐시 사용하지 않도록 설정
 
-                    webViewClient = WebViewClient()
+                    this.webViewClient = webViewClient
+                    this.webChromeClient = webChromeClient
 
-                    if (place.contains("동행복권")) {
-                        loadUrl("https://m.map.naver.com/search2/search.naver?query=%EB%8F%99%ED%96%89%EB%B3%B5%EA%B6%8C&sm=hty&style=v5#/map/1/1706795753")
-                    } else loadUrl("https://m.map.naver.com/search2/search.naver?query=$encodedPlace&sm=hty&style=v5#/map/1")
+                    loadUrl(url)
                 }
-            }
+            },
         )
+
         LottoMateTopAppBar(
-            titleRes = R.string.guide_title,
+            titleRes = title,
             hasNavigation = true,
             onBackPressed = onBackPressed,
-        )
-    }
-}
-
-@Preview(showBackground = true)
-@Composable
-private fun LottoMateWebViewPreview() {
-    LottoMateTheme {
-        LottoMateNaverMapWebView(
-            place = "www.naver.com",
-            onBackPressed = {},
         )
     }
 }

--- a/app/src/main/java/com/lottomate/lottomate/presentation/component/Webviews.kt
+++ b/app/src/main/java/com/lottomate/lottomate/presentation/component/Webviews.kt
@@ -1,0 +1,74 @@
+package com.lottomate.lottomate.presentation.component
+
+import android.webkit.WebView
+import android.webkit.WebViewClient
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.viewinterop.AndroidView
+import com.lottomate.lottomate.R
+import com.lottomate.lottomate.presentation.res.Dimens
+import com.lottomate.lottomate.presentation.ui.LottoMateTheme
+import com.lottomate.lottomate.presentation.ui.LottoMateWhite
+import java.net.URLEncoder
+
+@Composable
+fun LottoMateNaverMapWebView(
+    place: String,
+    onBackPressed: () -> Unit,
+) {
+    val context = LocalContext.current
+
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(LottoMateWhite),
+    ) {
+        val encodedPlace = URLEncoder.encode(place, "UTF-8")
+
+        AndroidView(
+            modifier = Modifier
+                .padding(top = Dimens.BaseTopPadding)
+                .fillMaxSize(),
+            factory = {
+                WebView(context).apply {
+                    settings.javaScriptEnabled = true
+                    settings.domStorageEnabled = true
+                    settings.useWideViewPort = true
+                    settings.loadWithOverviewMode = true
+                    settings.setSupportZoom(true)
+                    settings.builtInZoomControls = true
+                    settings.displayZoomControls = false
+
+
+                    webViewClient = WebViewClient()
+
+                    if (place.contains("동행복권")) {
+                        loadUrl("https://m.map.naver.com/search2/search.naver?query=%EB%8F%99%ED%96%89%EB%B3%B5%EA%B6%8C&sm=hty&style=v5#/map/1/1706795753")
+                    } else loadUrl("https://m.map.naver.com/search2/search.naver?query=$encodedPlace&sm=hty&style=v5#/map/1")
+                }
+            }
+        )
+        LottoMateTopAppBar(
+            titleRes = R.string.guide_title,
+            hasNavigation = true,
+            onBackPressed = onBackPressed,
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun LottoMateWebViewPreview() {
+    LottoMateTheme {
+        LottoMateNaverMapWebView(
+            place = "www.naver.com",
+            onBackPressed = {},
+        )
+    }
+}

--- a/app/src/main/java/com/lottomate/lottomate/presentation/navigation/RouteModel.kt
+++ b/app/src/main/java/com/lottomate/lottomate/presentation/navigation/RouteModel.kt
@@ -14,6 +14,7 @@ sealed interface LottoMateRoute {
     // 로또 상세
     @Serializable data class LottoDetail(val type: LottoType, val round: Int) : LottoMateRoute
     @Serializable data object LottoWinnerGuide : LottoMateRoute
+    @Serializable data class NaverMap(val place: String) : LottoMateRoute
 
     // 인터뷰
     @Serializable data object Interview : LottoMateRoute

--- a/app/src/main/java/com/lottomate/lottomate/presentation/screen/home/navigation/HomeNavigation.kt
+++ b/app/src/main/java/com/lottomate/lottomate/presentation/screen/home/navigation/HomeNavigation.kt
@@ -9,12 +9,14 @@ import androidx.navigation.toRoute
 import com.lottomate.lottomate.data.error.LottoMateErrorType
 import com.lottomate.lottomate.data.model.LottoType
 import com.lottomate.lottomate.presentation.component.BannerType
+import com.lottomate.lottomate.presentation.component.LottoMateNaverMapWebView
 import com.lottomate.lottomate.presentation.navigation.BottomTabRoute
 import com.lottomate.lottomate.presentation.navigation.LottoMateRoute
 import com.lottomate.lottomate.presentation.screen.home.HomeRoute
 import com.lottomate.lottomate.presentation.screen.interview.InterviewRoute
 import com.lottomate.lottomate.presentation.screen.lottoinfo.LottoInfoRoute
 import com.lottomate.lottomate.presentation.screen.map.navigation.navigateToMap
+import com.lottomate.lottomate.presentation.screen.map.navigation.navigateToMapTab
 import com.lottomate.lottomate.presentation.screen.scan.LottoScanRoute
 import com.lottomate.lottomate.presentation.screen.scanResult.LottoScanResultRoute
 import com.lottomate.lottomate.presentation.screen.setting.navigation.navigateToSetting
@@ -43,6 +45,10 @@ fun NavController.navigateToLottoScanResult(data: String) {
 
 fun NavController.navigateToBanner(bannerType: BannerType) {
     navigate(bannerType.route)
+}
+
+fun NavController.navigateToNaverMap(url: String) {
+    navigate(LottoMateRoute.NaverMap(url))
 }
 
 fun NavGraphBuilder.homeNavGraph(
@@ -119,10 +125,25 @@ fun NavGraphBuilder.homeNavGraph(
     // 당첨자 가이드 화면 (배너)
     composable<LottoMateRoute.LottoWinnerGuide> {
         WinnerGuideRoute(
-            onClickBanner = {
-                // TODO : 지도로 이동
+            moveToMap = {
+                val navOptions = NavOptions.Builder().apply {
+                    setPopUpTo<LottoMateRoute.LottoWinnerGuide>(inclusive = true)
+                }.build()
+
+                navController.navigateToMapTab(navOptions)
             },
+            moveToNaverMap = { navController.navigateToNaverMap(it) },
             onBackPressed = { navController.popBackStack() },
+        )
+    }
+
+    // 네이버 지도
+    composable<LottoMateRoute.NaverMap> { navBackStackEntry ->
+        val place = navBackStackEntry.toRoute<LottoMateRoute.NaverMap>().place
+
+        LottoMateNaverMapWebView(
+            place = place,
+            onBackPressed = { navController.navigateUp() },
         )
     }
 }

--- a/app/src/main/java/com/lottomate/lottomate/presentation/screen/home/navigation/HomeNavigation.kt
+++ b/app/src/main/java/com/lottomate/lottomate/presentation/screen/home/navigation/HomeNavigation.kt
@@ -9,7 +9,6 @@ import androidx.navigation.toRoute
 import com.lottomate.lottomate.data.error.LottoMateErrorType
 import com.lottomate.lottomate.data.model.LottoType
 import com.lottomate.lottomate.presentation.component.BannerType
-import com.lottomate.lottomate.presentation.component.LottoMateNaverMapWebView
 import com.lottomate.lottomate.presentation.navigation.BottomTabRoute
 import com.lottomate.lottomate.presentation.navigation.LottoMateRoute
 import com.lottomate.lottomate.presentation.screen.home.HomeRoute
@@ -20,6 +19,7 @@ import com.lottomate.lottomate.presentation.screen.map.navigation.navigateToMapT
 import com.lottomate.lottomate.presentation.screen.scan.LottoScanRoute
 import com.lottomate.lottomate.presentation.screen.scanResult.LottoScanResultRoute
 import com.lottomate.lottomate.presentation.screen.setting.navigation.navigateToSetting
+import com.lottomate.lottomate.presentation.screen.winnerguide.WinnerGuideNaverMapWebView
 import com.lottomate.lottomate.presentation.screen.winnerguide.WinnerGuideRoute
 import com.lottomate.lottomate.presentation.screen.winnerguide.navigation.navigateToWinnerGuide
 
@@ -137,11 +137,11 @@ fun NavGraphBuilder.homeNavGraph(
         )
     }
 
-    // 네이버 지도
+    // 당첨자 가이드 네이버 지도
     composable<LottoMateRoute.NaverMap> { navBackStackEntry ->
         val place = navBackStackEntry.toRoute<LottoMateRoute.NaverMap>().place
 
-        LottoMateNaverMapWebView(
+        WinnerGuideNaverMapWebView(
             place = place,
             onBackPressed = { navController.navigateUp() },
         )

--- a/app/src/main/java/com/lottomate/lottomate/presentation/screen/winnerguide/WinnerGuideNaverMapWebView.kt
+++ b/app/src/main/java/com/lottomate/lottomate/presentation/screen/winnerguide/WinnerGuideNaverMapWebView.kt
@@ -1,0 +1,63 @@
+package com.lottomate.lottomate.presentation.screen.winnerguide
+
+import android.graphics.Bitmap
+import android.util.Log
+import android.webkit.GeolocationPermissions
+import android.webkit.WebChromeClient
+import android.webkit.WebView
+import android.webkit.WebViewClient
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import com.lottomate.lottomate.R
+import com.lottomate.lottomate.presentation.component.LottoMateBasicWebView
+import com.lottomate.lottomate.utils.LocationStateManager
+import java.net.URLEncoder
+
+@Composable
+fun WinnerGuideNaverMapWebView(
+    place: String,
+    onBackPressed: () -> Unit,
+) {
+    val location by LocationStateManager.location.collectAsState()
+
+    val webViewClient = object : WebViewClient() {
+        override fun onPageStarted(view: WebView?, url: String?, favicon: Bitmap?) {
+            super.onPageStarted(view, url, favicon)
+            Log.d("NaverMapWebView", "onPageStarted: $url")
+        }
+
+        override fun onPageFinished(view: WebView?, url: String?) {
+            super.onPageFinished(view, url)
+            Log.d("NaverMapWebView", "onPageFinished: $url")
+        }
+    }
+
+    val webChromeClient = object : WebChromeClient() {
+        override fun onGeolocationPermissionsShowPrompt(
+            origin: String?,
+            callback: GeolocationPermissions.Callback?
+        ) {
+            callback?.invoke(origin, true, false)
+        }
+    }
+
+    val encodedPlace = URLEncoder.encode(place, "UTF-8")
+
+    LottoMateBasicWebView(
+        title = R.string.guide_title,
+        url = when {
+            place.contains("동행복권") -> "https://m.map.naver.com/search2/search.naver?query=%EB%8F%99%ED%96%89%EB%B3%B5%EA%B6%8C&sm=hty&style=v5#/map/1/1706795753"
+            place.contains("농협은행") -> {
+                Log.d("NaverMapWebView", "location : $location")
+                val coordKey = location?.let { "${it.latitude}:${it.longitude}" } ?: "37.7410651:127.0971133"
+
+                "https://m.map.naver.com/search2/search.naver?query=$encodedPlace&style=v5&sm=clk&centerCoord=$coordKey#/map/1"
+            }
+            else -> "https://m.map.naver.com/search2/search.naver?query=$encodedPlace&sm=hty&style=v5#/map/1"
+        },
+        webViewClient = webViewClient,
+        webChromeClient = webChromeClient,
+        onBackPressed = onBackPressed,
+    )
+}

--- a/app/src/main/java/com/lottomate/lottomate/presentation/screen/winnerguide/WinnerGuideNaverMapWebView.kt
+++ b/app/src/main/java/com/lottomate/lottomate/presentation/screen/winnerguide/WinnerGuideNaverMapWebView.kt
@@ -19,7 +19,7 @@ fun WinnerGuideNaverMapWebView(
     place: String,
     onBackPressed: () -> Unit,
 ) {
-    val location by LocationStateManager.location.collectAsState()
+    val location by LocationStateManager.currentLocation.collectAsState()
 
     val webViewClient = object : WebViewClient() {
         override fun onPageStarted(view: WebView?, url: String?, favicon: Bitmap?) {

--- a/app/src/main/java/com/lottomate/lottomate/presentation/screen/winnerguide/WinnerGuideScreen.kt
+++ b/app/src/main/java/com/lottomate/lottomate/presentation/screen/winnerguide/WinnerGuideScreen.kt
@@ -54,7 +54,7 @@ private fun WinnerGuideScreen(
     onClickBanner: (BannerType) -> Unit,
     onBackPressed: () -> Unit,
 ) {
-    var currentLottoType by remember { mutableIntStateOf(2) }
+    var currentLottoType by remember { mutableIntStateOf(0) }
 
     Box(
         modifier = modifier

--- a/app/src/main/java/com/lottomate/lottomate/presentation/screen/winnerguide/WinnerGuideScreen.kt
+++ b/app/src/main/java/com/lottomate/lottomate/presentation/screen/winnerguide/WinnerGuideScreen.kt
@@ -39,11 +39,16 @@ import com.lottomate.lottomate.presentation.screen.winnerguide.model.WinnerGuide
 
 @Composable
 fun WinnerGuideRoute(
-    onClickBanner: (BannerType) -> Unit,
+    moveToMap: () -> Unit,
+    moveToNaverMap: (String) -> Unit,
     onBackPressed: () -> Unit,
 ) {
     WinnerGuideScreen(
-        onClickBanner = onClickBanner,
+        onClickClaimAddress = { place ->
+            if (place.isEmpty()) moveToMap()
+            else moveToNaverMap(place)
+        },
+        onClickBanner = { moveToMap() },
         onBackPressed = onBackPressed,
     )
 }
@@ -51,6 +56,7 @@ fun WinnerGuideRoute(
 @Composable
 private fun WinnerGuideScreen(
     modifier: Modifier = Modifier,
+    onClickClaimAddress: (String) -> Unit,
     onClickBanner: (BannerType) -> Unit,
     onBackPressed: () -> Unit,
 ) {
@@ -82,6 +88,7 @@ private fun WinnerGuideScreen(
             TopPrizeClaimLocation(
                 modifier = Modifier.padding(top = 24.dp),
                 type = WinnerGuideType.findWinnerGuide(LottoType.findLottoType(currentLottoType)),
+                onClickClaimAddress = onClickClaimAddress,
             )
 
             MiddlePrizeClaimSection(

--- a/app/src/main/java/com/lottomate/lottomate/presentation/screen/winnerguide/component/TopPrizeClaimLocationSection.kt
+++ b/app/src/main/java/com/lottomate/lottomate/presentation/screen/winnerguide/component/TopPrizeClaimLocationSection.kt
@@ -167,7 +167,6 @@ private fun TopPrizeClaimLocationItem(
     modifier: Modifier = Modifier,
     rank: String,
     claimLocation: String,
-    claimLatLng: LatLng? = null,
     requiredItems: List<String>,
     hasCaption: Boolean = false,
 ) {
@@ -211,20 +210,15 @@ private fun TopPrizeClaimLocationItem(
                     modifier = Modifier.padding(start = 4.dp),
                 )
 
-                // 장소 위/경도 값이 있을 때에만 아이콘 노출
-                claimLatLng?.let {
-                    Icon(
-                        painter = painterResource(id = R.drawable.icon_place),
-                        contentDescription = null,
-                        modifier = Modifier
-                            .padding(start = 4.dp)
-                            .size(14.dp)
-                            .noInteractionClickable {
-                                // TODO : 지도 아이콘 클릭 시, 지도 표시
-                            },
-                        tint = LottoMateGray100,
-                    )
-                }
+                Icon(
+                    painter = painterResource(id = R.drawable.icon_place),
+                    contentDescription = null,
+                    modifier = Modifier
+                        .padding(start = 4.dp)
+                        .size(14.dp)
+                        .noInteractionClickable { onClickClaimAddress() },
+                    tint = LottoMateGray100,
+                )
             }
 
             Row(

--- a/app/src/main/java/com/lottomate/lottomate/presentation/screen/winnerguide/component/TopPrizeClaimLocationSection.kt
+++ b/app/src/main/java/com/lottomate/lottomate/presentation/screen/winnerguide/component/TopPrizeClaimLocationSection.kt
@@ -29,12 +29,12 @@ import com.lottomate.lottomate.presentation.ui.LottoMateTheme
 import com.lottomate.lottomate.presentation.ui.LottoMateWhite
 import com.lottomate.lottomate.utils.dropShadow
 import com.lottomate.lottomate.utils.noInteractionClickable
-import com.naver.maps.geometry.LatLng
 
 @Composable
 fun TopPrizeClaimLocation(
     modifier: Modifier = Modifier,
     type: WinnerGuideType,
+    onClickClaimAddress: (String) -> Unit
 ) {
     Column(
         modifier = modifier.fillMaxWidth(),
@@ -66,6 +66,7 @@ fun TopPrizeClaimLocation(
                         rank = "1등",
                         claimLocation = "NH농협 본점",
                         requiredItems = listOf("당첨복권", "신분증"),
+                        onClickClaimAddress = { onClickClaimAddress("서울 중구 새문안로 16 농협중앙회 중앙본부") },
                     )
 
                     WinnerGuideHorizontalDivider()
@@ -75,6 +76,7 @@ fun TopPrizeClaimLocation(
                         hasCaption = true,
                         claimLocation = "NH농협 전국지점",
                         requiredItems = listOf("당첨복권", "신분증"),
+                        onClickClaimAddress = { onClickClaimAddress("농협은행") },
                     )
 
                     WinnerGuideHorizontalDivider()
@@ -83,6 +85,7 @@ fun TopPrizeClaimLocation(
                         rank = "4등, 5등",
                         claimLocation = "전국 복권 판매점",
                         requiredItems = listOf("당첨복권"),
+                        onClickClaimAddress = { onClickClaimAddress("") },
                     )
                 }
                 WinnerGuideType.LOTTO720 -> {
@@ -91,6 +94,7 @@ fun TopPrizeClaimLocation(
                         claimLocation = "동행복권 본사",
                         requiredItems = listOf("당첨복권", "신분증", "통장사본"),
                         hasCaption = true,
+                        onClickClaimAddress = { onClickClaimAddress("동행복권") },
                     )
 
                     WinnerGuideHorizontalDivider()
@@ -99,6 +103,7 @@ fun TopPrizeClaimLocation(
                         rank = "3등, 4등",
                         claimLocation = "NH농협 전국지점",
                         requiredItems = listOf("당첨복권", "신분증"),
+                        onClickClaimAddress = { onClickClaimAddress("농협은행") },
                     )
 
                     WinnerGuideHorizontalDivider()
@@ -107,6 +112,7 @@ fun TopPrizeClaimLocation(
                         rank = "5등, 6등, 7등",
                         claimLocation = "전국 복권 판매점",
                         requiredItems = listOf("당첨복권"),
+                        onClickClaimAddress = { onClickClaimAddress("") },
                     )
 
                     WinnerGuideHorizontalDivider()
@@ -116,6 +122,7 @@ fun TopPrizeClaimLocation(
                         claimLocation = "동행복권 본사",
                         requiredItems = listOf("당첨복권", "신분증", "통장사본"),
                         hasCaption = true,
+                        onClickClaimAddress = { onClickClaimAddress("동행복권") },
                     )
                 }
                 WinnerGuideType.SPEETTO -> {
@@ -123,6 +130,7 @@ fun TopPrizeClaimLocation(
                         rank = "1억 이상",
                         claimLocation = "동행복권 본사",
                         requiredItems = listOf("당첨복권", "신분증"),
+                        onClickClaimAddress = { onClickClaimAddress("동행복권") },
                     )
 
                     WinnerGuideHorizontalDivider()
@@ -131,6 +139,7 @@ fun TopPrizeClaimLocation(
                         rank = "200만원 초과 1억원 이하",
                         claimLocation = "NH농협 전국지점",
                         requiredItems = listOf("당첨복권", "신분증"),
+                        onClickClaimAddress = { onClickClaimAddress("농협은행") },
                     )
 
                     WinnerGuideHorizontalDivider()
@@ -139,6 +148,7 @@ fun TopPrizeClaimLocation(
                         rank = "5만원 초과 200만원 이하",
                         claimLocation = "NH농협 전국지점",
                         requiredItems = listOf("당첨복권"),
+                        onClickClaimAddress = { onClickClaimAddress("농협은행") },
                     )
 
                     WinnerGuideHorizontalDivider()
@@ -147,6 +157,7 @@ fun TopPrizeClaimLocation(
                         rank = "5만원 이하",
                         claimLocation = "전국 복권 판매점",
                         requiredItems = listOf("당첨복권"),
+                        onClickClaimAddress = { onClickClaimAddress("") },
                     )
                 }
             }
@@ -169,6 +180,7 @@ private fun TopPrizeClaimLocationItem(
     claimLocation: String,
     requiredItems: List<String>,
     hasCaption: Boolean = false,
+    onClickClaimAddress: () -> Unit,
 ) {
     Row(
         modifier = modifier.fillMaxWidth(),


### PR DESCRIPTION
## 💡 ISSUE
- #45 

</br>

## 📝 작업 내용
- 당첨금 수령 장소 지도 아이콘 추가
- 웹뷰를 사용하여 네이버 지도 표시
- 네이버 지도에 각 당첨금 수령 장소 표시 
- 사용자 위치 상태를 mutableStateOf에서 StateFlow로 변경

### 사용자 위치 상태를 StateFlow로 변경한 이유
지도 화면 외에도 추가적으로 당첨금 수령 장소에서 사용자 GPS 데이터를 사용하게 되어 전역적으로 관리할 필요가 있을 것 같았다.

``` kotlin
locationService.getCurrentLocation(LocationRequest.PRIORITY_HIGH_ACCURACY, null)
```
사용자 데이터를 가져오는  getCurrentLocation() 함수는 비동기적으로 동작하기 때문에 완료가 되었을 때 상태가 업데이트 되어질텐데 이 상태를 관찰하고 있어야 사용자에게 알맞은 화면을 보여줄 수 있을 것 같았다.

</br>

## 📸 ScreenShot (Optional)
|`NH농협 본사`|`전국 NH농협 지점`|`동행복권 본사`|
|:--:|:--:|:--:|
|![NH농협본사](https://github.com/user-attachments/assets/37833874-9186-4b40-91a2-4135e4f53a11)|![NH농협지점](https://github.com/user-attachments/assets/ae57ee31-11ad-4ad2-8dfa-f92a3d1e8ae4)|![동행복권본사](https://github.com/user-attachments/assets/15b74c3c-68fd-4bff-bcff-75c1c6352adc)|
