### PR TITLE
[LTM-138] 당첨 후기 노출 로직 개발 및 UI 수정

### DIFF
--- a/app/src/main/java/com/lottomate/lottomate/data/manager/InterviewViewManager.kt
+++ b/app/src/main/java/com/lottomate/lottomate/data/manager/InterviewViewManager.kt
@@ -1,0 +1,6 @@
+package com.lottomate.lottomate.data.manager
+
+interface InterviewViewManager {
+    suspend fun addInterviewId(id: Int)
+    suspend fun getUnviewedInterviewIds(latestInterviewId: Int): List<Int>
+}

--- a/app/src/main/java/com/lottomate/lottomate/data/manager/InterviewViewManagerImpl.kt
+++ b/app/src/main/java/com/lottomate/lottomate/data/manager/InterviewViewManagerImpl.kt
@@ -1,0 +1,37 @@
+package com.lottomate.lottomate.data.manager
+
+import com.lottomate.lottomate.data.datastore.LottoMateDataStore
+import com.lottomate.lottomate.data.model.InterviewViewEntity
+import com.lottomate.lottomate.utils.DateUtils
+import javax.inject.Inject
+
+class InterviewViewManagerImpl @Inject constructor(
+
+) : InterviewViewManager {
+    override suspend fun addInterviewId(id: Int) {
+        val current = LottoMateDataStore.getInterviewViewed()
+
+        val update = current.copy(interviewIds = current.interviewIds + id)
+        LottoMateDataStore.saveInterviewViewed(update)
+    }
+
+    override suspend fun getUnviewedInterviewIds(latestInterviewId: Int): List<Int> {
+        var current = LottoMateDataStore.getInterviewViewed()
+
+        val unviewed = (latestInterviewId downTo 1)
+            .filterNot { current.interviewIds.contains(it) }
+
+        if (unviewed.isEmpty()) {
+            current = InterviewViewEntity(DateUtils.getCurrentDate(), emptySet())
+            LottoMateDataStore.saveInterviewViewed(current)
+        }
+
+        return (latestInterviewId downTo 1)
+            .filterNot { current.interviewIds.contains(it) }
+            .take(DEFAULT_COUNT)
+    }
+
+    companion object {
+        private const val DEFAULT_COUNT = 5
+    }
+}

--- a/app/src/main/java/com/lottomate/lottomate/data/manager/di/ManagerModule.kt
+++ b/app/src/main/java/com/lottomate/lottomate/data/manager/di/ManagerModule.kt
@@ -1,0 +1,19 @@
+package com.lottomate.lottomate.data.manager.di
+
+import com.lottomate.lottomate.data.manager.InterviewViewManager
+import com.lottomate.lottomate.data.manager.InterviewViewManagerImpl
+import dagger.Binds
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+abstract class ManagerModule {
+    @Binds
+    @Singleton
+    abstract fun bindInterviewViewManager(
+        interviewViewManagerImpl: InterviewViewManagerImpl
+    ): InterviewViewManager
+}

--- a/app/src/main/java/com/lottomate/lottomate/data/mapper/InterviewMapper.kt
+++ b/app/src/main/java/com/lottomate/lottomate/data/mapper/InterviewMapper.kt
@@ -1,10 +1,12 @@
 package com.lottomate.lottomate.data.mapper
 
 import com.lottomate.lottomate.data.remote.response.interview.ResponseInterviewDetail
+import com.lottomate.lottomate.data.remote.response.interview.ResponseInterviewsInfo
+import com.lottomate.lottomate.presentation.screen.interview.model.InterviewUiModel
 import com.lottomate.lottomate.presentation.screen.interview.model.InterviewQnA
-import com.lottomate.lottomate.presentation.screen.interview.model.InterviewUIModel
+import com.lottomate.lottomate.presentation.screen.interview.model.InterviewDetailUiModel
 
-fun ResponseInterviewDetail.toUIModel(): InterviewUIModel {
+fun ResponseInterviewDetail.toUIModel(): InterviewDetailUiModel {
     val contents = reviewCont
         .split("▶")
         .filter { it.isNotBlank() }
@@ -18,7 +20,7 @@ fun ResponseInterviewDetail.toUIModel(): InterviewUIModel {
         InterviewQnA(question, answer)
     }
 
-    return InterviewUIModel(
+    return InterviewDetailUiModel(
         no = reviewNo,
         originalNo = reviewHref,
         title = reviewTitle,
@@ -29,3 +31,11 @@ fun ResponseInterviewDetail.toUIModel(): InterviewUIModel {
         contents = qna.toList(),
     )
 }
+
+fun ResponseInterviewsInfo.toUiModel() = InterviewUiModel(
+    no = this.reviewNo,
+    title = this.reviewTitle,
+    thumbs = this.reviewThumb,
+    date = this.intrvDate.replace("-", "."),
+    place = this.reviewPlace,
+)

--- a/app/src/main/java/com/lottomate/lottomate/data/mapper/InterviewMapper.kt
+++ b/app/src/main/java/com/lottomate/lottomate/data/mapper/InterviewMapper.kt
@@ -1,5 +1,6 @@
 package com.lottomate.lottomate.data.mapper
 
+import com.lottomate.lottomate.R
 import com.lottomate.lottomate.data.remote.response.interview.ResponseInterviewDetail
 import com.lottomate.lottomate.data.remote.response.interview.ResponseInterviewsInfo
 import com.lottomate.lottomate.presentation.screen.interview.model.InterviewUiModel
@@ -35,7 +36,17 @@ fun ResponseInterviewDetail.toUIModel(): InterviewDetailUiModel {
 fun ResponseInterviewsInfo.toUiModel() = InterviewUiModel(
     no = this.reviewNo,
     title = this.reviewTitle,
-    thumbs = this.reviewThumb,
+    thumbs = "",
+    emptyThumbs = randomEmptyThumbnailId(),
     date = this.intrvDate.replace("-", "."),
     place = this.reviewPlace,
 )
+
+fun randomEmptyThumbnailId(): Int {
+    val random = (0..1).random()
+
+    return when (random) {
+        0 -> R.drawable.img_interview_empty01
+        else -> R.drawable.img_interview_empty02
+    }
+}

--- a/app/src/main/java/com/lottomate/lottomate/data/mapper/InterviewMapper.kt
+++ b/app/src/main/java/com/lottomate/lottomate/data/mapper/InterviewMapper.kt
@@ -36,7 +36,7 @@ fun ResponseInterviewDetail.toUIModel(): InterviewDetailUiModel {
 fun ResponseInterviewsInfo.toUiModel() = InterviewUiModel(
     no = this.reviewNo,
     title = this.reviewTitle,
-    thumbs = "",
+    thumbs = this.reviewThumb,
     emptyThumbs = randomEmptyThumbnailId(),
     date = this.intrvDate.replace("-", "."),
     place = this.reviewPlace,

--- a/app/src/main/java/com/lottomate/lottomate/data/model/InterviewViewEntity.kt
+++ b/app/src/main/java/com/lottomate/lottomate/data/model/InterviewViewEntity.kt
@@ -1,5 +1,8 @@
 package com.lottomate.lottomate.data.model
 
+import kotlinx.serialization.Serializable
+
+@Serializable
 data class InterviewViewEntity(
     val date: String,
     val interviewIds: Set<Int>,

--- a/app/src/main/java/com/lottomate/lottomate/data/model/InterviewViewEntity.kt
+++ b/app/src/main/java/com/lottomate/lottomate/data/model/InterviewViewEntity.kt
@@ -1,0 +1,6 @@
+package com.lottomate.lottomate.data.model
+
+data class InterviewViewEntity(
+    val date: String,
+    val interviewIds: Set<Int>,
+)

--- a/app/src/main/java/com/lottomate/lottomate/data/remote/repository/InterviewRepositoryImpl.kt
+++ b/app/src/main/java/com/lottomate/lottomate/data/remote/repository/InterviewRepositoryImpl.kt
@@ -1,33 +1,60 @@
 package com.lottomate.lottomate.data.remote.repository
 
+import android.util.Log
+import com.lottomate.lottomate.data.manager.InterviewViewManager
 import com.lottomate.lottomate.data.mapper.toUIModel
+import com.lottomate.lottomate.data.mapper.toUiModel
 import com.lottomate.lottomate.data.remote.api.InterviewApi
-import com.lottomate.lottomate.data.remote.response.interview.ResponseInterviewsInfo
 import com.lottomate.lottomate.domain.repository.InterviewRepository
-import com.lottomate.lottomate.presentation.screen.interview.model.InterviewUIModel
+import com.lottomate.lottomate.presentation.screen.interview.model.InterviewDetailUiModel
+import com.lottomate.lottomate.presentation.screen.interview.model.InterviewUiModel
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.update
 import javax.inject.Inject
 
 class InterviewRepositoryImpl @Inject constructor(
     private val interviewApi: InterviewApi,
+    private val interviewViewManager: InterviewViewManager,
 ) : InterviewRepository {
-    override suspend fun fetchLatestNoOfInterview(): Int {
-        val result = interviewApi.getLatestNoOfInterview()
+    private val _interviews = MutableStateFlow<List<InterviewUiModel>>(emptyList())
+    override val interviews: StateFlow<List<InterviewUiModel>>
+        get() = _interviews.asStateFlow()
 
-        return result
+    override suspend fun fetchInterviews(): Result<Unit> {
+        return try {
+            val interviewLatestNo = fetchLatestInterviewNo().getOrThrow()
+            val interviewNo = interviewViewManager.getUnviewedInterviewIds(interviewLatestNo)
+
+            val interviewNoToString = interviewNo.joinToString(",")
+            val response = interviewApi.getInterviews(interviewNoToString)
+
+            _interviews.update { response.map { it.toUiModel() }.sortedByDescending { it.no } }
+            Result.success(Unit)
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
     }
 
-    override suspend fun fetchInterviews(interviewNo: List<Int>): Flow<List<ResponseInterviewsInfo>> = flow {
-        val interviewNoToString = interviewNo.joinToString(",")
-        val interviews = interviewApi.getInterviews(interviewNoToString)
-
-        emit(interviews)
-    }
-
-    override suspend fun fetchInterview(interviewNo: Int): Flow<InterviewUIModel> = flow {
+    override suspend fun fetchInterview(interviewNo: Int): Flow<InterviewDetailUiModel> = flow {
         val result = interviewApi.getInterviewDetail(interviewNo)
+        interviewViewManager.addInterviewId(result.reviewNo)
 
+        fetchInterviews()
         emit(result.toUIModel())
+    }
+
+    private suspend fun fetchLatestInterviewNo(): Result<Int> {
+        return try {
+            val result = interviewApi.getLatestNoOfInterview()
+
+            Result.success(result)
+        } catch (e: Exception) {
+            Log.d("InterviewRepo", "fetchLatestNoOfInterview: $e")
+            Result.failure(e)
+        }
     }
 }

--- a/app/src/main/java/com/lottomate/lottomate/domain/repository/InterviewRepository.kt
+++ b/app/src/main/java/com/lottomate/lottomate/domain/repository/InterviewRepository.kt
@@ -1,11 +1,13 @@
 package com.lottomate.lottomate.domain.repository
 
-import com.lottomate.lottomate.data.remote.response.interview.ResponseInterviewsInfo
-import com.lottomate.lottomate.presentation.screen.interview.model.InterviewUIModel
+import com.lottomate.lottomate.presentation.screen.interview.model.InterviewDetailUiModel
+import com.lottomate.lottomate.presentation.screen.interview.model.InterviewUiModel
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.StateFlow
 
 interface InterviewRepository {
-    suspend fun fetchLatestNoOfInterview(): Int
-    suspend fun fetchInterviews(interviewNo: List<Int>): Flow<List<ResponseInterviewsInfo>>
-    suspend fun fetchInterview(interviewNo: Int): Flow<InterviewUIModel>
+    val interviews: StateFlow<List<InterviewUiModel>>
+
+    suspend fun fetchInterview(interviewNo: Int): Flow<InterviewDetailUiModel>
+    suspend fun fetchInterviews(): Result<Unit>
 }

--- a/app/src/main/java/com/lottomate/lottomate/presentation/component/Webviews.kt
+++ b/app/src/main/java/com/lottomate/lottomate/presentation/component/Webviews.kt
@@ -7,8 +7,12 @@ import android.webkit.WebViewClient
 import androidx.annotation.StringRes
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
@@ -31,31 +35,38 @@ fun LottoMateBasicWebView(
             .fillMaxSize()
             .background(LottoMateWhite),
     ) {
-        AndroidView(
+        Column(
             modifier = Modifier
-                .padding(top = Dimens.BaseTopPadding)
-                .fillMaxSize(),
-            factory = {
-                WebView(context).apply {
-                    settings.javaScriptEnabled = true
-                    settings.domStorageEnabled = true
-                    settings.useWideViewPort = true
-                    settings.loadWithOverviewMode = true
-                    settings.setSupportZoom(true)
-                    settings.builtInZoomControls = true
-                    settings.displayZoomControls = false
+                .fillMaxSize()
+                .verticalScroll(rememberScrollState())
+        ) {
+            Spacer(modifier = Modifier.height(Dimens.BaseTopPadding))
 
-                    clearCache(true) // 캐시 제거
-                    clearHistory()   // 기록 제거
-                    settings.cacheMode = WebSettings.LOAD_NO_CACHE // 캐시 사용하지 않도록 설정
+            AndroidView(
+                modifier = Modifier.fillMaxSize(),
+                factory = {
+                    WebView(context).apply {
+                        settings.javaScriptEnabled = true
+                        settings.domStorageEnabled = true
+                        settings.useWideViewPort = true
+                        settings.loadWithOverviewMode = true
+                        settings.setSupportZoom(true)
+                        settings.builtInZoomControls = true
+                        settings.displayZoomControls = false
 
-                    this.webViewClient = webViewClient
-                    this.webChromeClient = webChromeClient
+                        clearCache(true) // 캐시 제거
+                        clearHistory()   // 기록 제거
+                        settings.cacheMode = WebSettings.LOAD_NO_CACHE // 캐시 사용하지 않도록 설정
 
-                    loadUrl(url)
-                }
-            },
-        )
+                        this.webViewClient = webViewClient
+                        this.webChromeClient = webChromeClient
+
+                        loadUrl(url)
+                    }
+                },
+            )
+        }
+
 
         LottoMateTopAppBar(
             titleRes = title,

--- a/app/src/main/java/com/lottomate/lottomate/presentation/navigation/RouteModel.kt
+++ b/app/src/main/java/com/lottomate/lottomate/presentation/navigation/RouteModel.kt
@@ -18,6 +18,8 @@ sealed interface LottoMateRoute {
 
     // 인터뷰
     @Serializable data class InterviewDetail(val no: Int, val place: String) : LottoMateRoute
+    @Serializable data class OriginalInterview(val no: Int) : LottoMateRoute
+
     // 로그인
     @Serializable data object Login : LottoMateRoute
     @Serializable data object LoginComplete : LottoMateRoute

--- a/app/src/main/java/com/lottomate/lottomate/presentation/screen/home/component/WinInterviewsSection.kt
+++ b/app/src/main/java/com/lottomate/lottomate/presentation/screen/home/component/WinInterviewsSection.kt
@@ -32,9 +32,9 @@ import androidx.compose.ui.unit.dp
 import coil.compose.AsyncImage
 import coil.request.ImageRequest
 import com.lottomate.lottomate.R
-import com.lottomate.lottomate.data.remote.response.interview.ResponseInterviewsInfo
 import com.lottomate.lottomate.presentation.component.LottoMateText
 import com.lottomate.lottomate.presentation.res.Dimens
+import com.lottomate.lottomate.presentation.screen.interview.model.InterviewUiModel
 import com.lottomate.lottomate.presentation.ui.LottoMateBlack
 import com.lottomate.lottomate.presentation.ui.LottoMateGray100
 import com.lottomate.lottomate.presentation.ui.LottoMateGray80
@@ -46,7 +46,7 @@ import com.lottomate.lottomate.utils.dropShadow
 @Composable
 internal fun WinInterviewCardsSection(
     modifier: Modifier = Modifier,
-    interviews: List<ResponseInterviewsInfo>,
+    interviews: List<InterviewUiModel>,
     onClickInterview: (Int, String) -> Unit,
 ) {
     val pagerState = rememberPagerState(
@@ -102,8 +102,8 @@ internal fun WinInterviewCardsSection(
                         .clip(RoundedCornerShape(Dimens.RadiusLarge))
                         .clickable {
                             onClickInterview(
-                                interviews[page].reviewNo,
-                                interviews[page].reviewPlace
+                                interviews[page].no,
+                                interviews[page].place
                             )
                         },
                     shape = RoundedCornerShape(Dimens.RadiusLarge),
@@ -111,7 +111,7 @@ internal fun WinInterviewCardsSection(
                     Column(
                         modifier = Modifier.background(LottoMateWhite)
                     ) {
-                        if (interviews[page].reviewThumb.isEmpty()) {
+                        if (interviews[page].thumbs.isEmpty()) {
 
                             Image(
                                 painter = painterResource(id = interviewCoverImgList[page]),
@@ -123,7 +123,7 @@ internal fun WinInterviewCardsSection(
                         } else {
                             AsyncImage(
                                 model = ImageRequest.Builder(LocalContext.current)
-                                    .data(interviews[page].reviewThumb)
+                                    .data(interviews[page].thumbs)
                                     .build(),
                                 contentDescription = "Lotto Interview Image",
                                 contentScale = ContentScale.Crop,
@@ -143,13 +143,13 @@ internal fun WinInterviewCardsSection(
                                 .padding(horizontal = 16.dp)
                         ) {
                             LottoMateText(
-                                text = interviews[page].reviewPlace,
+                                text = interviews[page].place,
                                 style = LottoMateTheme.typography.caption
                                     .copy(color = LottoMateGray80),
                             )
 
                             LottoMateText(
-                                text = interviews[page].reviewTitle,
+                                text = interviews[page].title,
                                 style = LottoMateTheme.typography.headline1
                                     .copy(color = LottoMateBlack),
                                 maxLines = 2,
@@ -159,7 +159,7 @@ internal fun WinInterviewCardsSection(
                             )
 
                             LottoMateText(
-                                text = interviews[page].intrvDate.replace("-", "."),
+                                text = interviews[page].date,
                                 style = LottoMateTheme.typography.caption
                                     .copy(color = LottoMateGray80),
                             )

--- a/app/src/main/java/com/lottomate/lottomate/presentation/screen/home/component/WinInterviewsSection.kt
+++ b/app/src/main/java/com/lottomate/lottomate/presentation/screen/home/component/WinInterviewsSection.kt
@@ -19,7 +19,6 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Card
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -52,15 +51,6 @@ internal fun WinInterviewCardsSection(
     val pagerState = rememberPagerState(
         pageCount = { interviews.size }
     )
-
-    val interviewCoverImgList = remember(interviews) {
-        List(interviews.size) {
-            when ((1..2).random()) {
-                1 -> R.drawable.img_interview_empty01
-                else -> R.drawable.img_interview_empty02
-            }
-        }
-    }
 
     Column {
         Column(
@@ -112,9 +102,8 @@ internal fun WinInterviewCardsSection(
                         modifier = Modifier.background(LottoMateWhite)
                     ) {
                         if (interviews[page].thumbs.isEmpty()) {
-
                             Image(
-                                painter = painterResource(id = interviewCoverImgList[page]),
+                                painter = painterResource(id = interviews[page].emptyThumbs),
                                 contentDescription = "interview image empty",
                                 modifier = Modifier
                                     .height(160.dp)
@@ -127,9 +116,8 @@ internal fun WinInterviewCardsSection(
                                     .build(),
                                 contentDescription = "Lotto Interview Image",
                                 contentScale = ContentScale.Crop,
-                                placeholder = painterResource(id = R.drawable.img_review),
-                                // TODO : 기본 이미지 변경 필요
-                                error = painterResource(id = R.drawable.img_review),
+                                placeholder = painterResource(id = interviews[page].emptyThumbs),
+                                error = painterResource(id = interviews[page].emptyThumbs),
                                 modifier = Modifier
                                     .height(160.dp)
                                     .fillMaxWidth(),

--- a/app/src/main/java/com/lottomate/lottomate/presentation/screen/home/navigation/HomeNavigation.kt
+++ b/app/src/main/java/com/lottomate/lottomate/presentation/screen/home/navigation/HomeNavigation.kt
@@ -12,7 +12,7 @@ import com.lottomate.lottomate.presentation.component.BannerType
 import com.lottomate.lottomate.presentation.navigation.BottomTabRoute
 import com.lottomate.lottomate.presentation.navigation.LottoMateRoute
 import com.lottomate.lottomate.presentation.screen.home.HomeRoute
-import com.lottomate.lottomate.presentation.screen.interview.InterviewRoute
+import com.lottomate.lottomate.presentation.screen.interview.navigation.navigateToInterviewDetail
 import com.lottomate.lottomate.presentation.screen.lottoinfo.LottoInfoRoute
 import com.lottomate.lottomate.presentation.screen.map.navigation.navigateToMap
 import com.lottomate.lottomate.presentation.screen.map.navigation.navigateToMapTab
@@ -25,10 +25,6 @@ import com.lottomate.lottomate.presentation.screen.winnerguide.navigation.naviga
 
 fun NavController.navigateToHomeTab(navOptions: NavOptions) {
     navigate(BottomTabRoute.Home, navOptions)
-}
-
-fun NavController.navigateToInterviewDetail(no: Int, place: String) {
-    navigate(LottoMateRoute.InterviewDetail(no, place))
 }
 
 fun NavController.navigateToLottoDetail(type: LottoType, round: Int) {
@@ -78,20 +74,6 @@ fun NavGraphBuilder.homeNavGraph(
             type = type,
             round = round,
             onClickBottomBanner = {},
-            onShowErrorSnackBar = onShowErrorSnackBar,
-            onBackPressed = { navController.navigateUp() },
-        )
-    }
-
-    // 인터뷰 상세 화면
-    composable<LottoMateRoute.InterviewDetail> {navBackStackEntry ->
-        val no = navBackStackEntry.toRoute<LottoMateRoute.InterviewDetail>().no
-        val place = navBackStackEntry.toRoute<LottoMateRoute.InterviewDetail>().place
-
-        InterviewRoute(
-            no = no,
-            place = place,
-            onClickBanner = { navController.navigateToBanner(BannerType.MAP) },
             onShowErrorSnackBar = onShowErrorSnackBar,
             onBackPressed = { navController.navigateUp() },
         )

--- a/app/src/main/java/com/lottomate/lottomate/presentation/screen/interview/InterviewScreen.kt
+++ b/app/src/main/java/com/lottomate/lottomate/presentation/screen/interview/InterviewScreen.kt
@@ -617,7 +617,7 @@ private fun BottomInterviewListContent(
 
         LazyRow(
             modifier = Modifier.fillMaxWidth(),
-            horizontalArrangement = Arrangement.spacedBy(16.dp, Alignment.CenterHorizontally),
+            horizontalArrangement = Arrangement.spacedBy(16.dp),
             contentPadding = PaddingValues(horizontal = 20.dp),
         ) {
             items(
@@ -645,22 +645,34 @@ private fun BottomInterviewListItem(
         onClick = onClick,
     ) {
         Column(modifier = Modifier.fillMaxWidth()) {
-            SubcomposeAsyncImage(
-                model = ImageRequest.Builder(context).apply {
-                    data(interview.thumbs)
-                    size(600)
-                    scale(Scale.FILL)
-                }
-                    .build(),
-                contentDescription = "interview thumbnail image",
-                error = {
-                    Image(painter = painterResource(id = R.drawable.img_interview_empty01), contentDescription = "interview Thumbnail error")
-                },
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .height(100.dp),
-                contentScale = ContentScale.Crop
-            )
+            if (interview.thumbs.isEmpty()) {
+                Image(
+                    painter = painterResource(id = interview.emptyThumbs),
+                    contentDescription = "interview Thumbnail empty",
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(100.dp),
+                )
+            } else {
+                SubcomposeAsyncImage(
+                    model = ImageRequest.Builder(context).apply {
+                        data(interview.thumbs)
+                        size(600)
+                        scale(Scale.FILL)
+                    }
+                        .build(),
+                    contentDescription = "interview thumbnail image",
+                    error = {
+                        Image(
+                            painter = painterResource(id = interview.emptyThumbs),
+                            contentDescription = "interview Thumbnail error")
+                    },
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(100.dp),
+                    contentScale = ContentScale.Crop
+                )
+            }
 
             Box(
                 modifier = Modifier
@@ -678,6 +690,7 @@ private fun BottomInterviewListItem(
                         style = LottoMateTheme.typography.label2
                             .copy(color = LottoMateBlack),
                         maxLines = 2,
+                        minLines = 2,
                         overflow = TextOverflow.Ellipsis,
                     )
                 }
@@ -698,7 +711,7 @@ private fun BottomInterviewListItem(
 private fun InterviewPreview() {
     LottoMateTheme {
         InterviewScreen(
-            uiState = InterviewUiState.Success(InterviewMockData, InterviewsMockDate),
+            uiState = InterviewUiState.Success(InterviewMockData, InterviewsMockData),
             scrollState = rememberLazyListState(),
             onBackPressed = {},
             onClickBanner = {},
@@ -717,7 +730,7 @@ private fun LongTitleInterviewPreview() {
                 InterviewMockData.copy(
                     title = "일이삼사오육칠팔구십일이삼사오육칠팔구십일이삼사오육칠팔구십일이"
                 ),
-                InterviewsMockDate,
+                InterviewsMockData,
             ),
             scrollState = rememberLazyListState(),
             onBackPressed = {},
@@ -733,7 +746,7 @@ private fun LongTitleInterviewPreview() {
 private fun InterviewEmptyImagePreview() {
     LottoMateTheme {
         InterviewScreen(
-            uiState = InterviewUiState.Success(InterviewMockData.copy(imgs = emptyList()), InterviewsMockDate),
+            uiState = InterviewUiState.Success(InterviewMockData.copy(imgs = emptyList()), InterviewsMockData),
             scrollState = rememberLazyListState(),
             onBackPressed = {},
             onClickBanner = {},
@@ -779,11 +792,12 @@ val InterviewMockData = InterviewDetailUiModel(
     place = "스피또 500, 29회차 1등 2억"
 )
 
-val InterviewsMockDate = List(5) {
+val InterviewsMockData = List(5) {
     InterviewUiModel(
         no = it,
         title = "인터뷰 목록 데이터 $it",
-        thumbs = "https://lottomate-review.s3.ap-northeast-2.amazonaws.com/13406_2.jpg",
+        thumbs = "",
+        emptyThumbs = R.drawable.img_interview_empty01,
         date = "2023.01.01",
         place = "스피또 500, 29회차 1등 2억",
     )

--- a/app/src/main/java/com/lottomate/lottomate/presentation/screen/interview/InterviewScreen.kt
+++ b/app/src/main/java/com/lottomate/lottomate/presentation/screen/interview/InterviewScreen.kt
@@ -88,6 +88,7 @@ fun InterviewRoute(
     vm: InterviewViewModel = hiltViewModel(),
     no: Int,
     place: String,
+    moveToOriginalInterview: (Int) -> Unit,
     onClickBanner: () -> Unit,
     onShowErrorSnackBar: (errorType: LottoMateErrorType) -> Unit,
     onBackPressed: () -> Unit,
@@ -117,9 +118,7 @@ fun InterviewRoute(
         onClickWinnerInterview = { no, place ->
             vm.getInterview(no, place)
         },
-        onClickOriginArticle = {
-
-        },
+        onClickOriginArticle = moveToOriginalInterview,
     )
 }
 
@@ -130,7 +129,7 @@ private fun InterviewScreen(
     onBackPressed: () -> Unit,
     onClickBanner: () -> Unit,
     onClickWinnerInterview: (Int, String) -> Unit,
-    onClickOriginArticle: () -> Unit,
+    onClickOriginArticle: (Int) -> Unit,
 ) {
     var showInterviewImage by remember { mutableStateOf(false) }
     var showInterviewImageIndex by remember { mutableStateOf(0) }
@@ -419,7 +418,7 @@ private fun InterviewImageView(
 private fun InterviewContentDetail(
     modifier: Modifier = Modifier,
     interview: InterviewDetailUiModel,
-    onClickOriginArticle: () -> Unit,
+    onClickOriginArticle: (Int) -> Unit,
     onClickInterviewImage: (Int) -> Unit,
 ) {
     Column(modifier = modifier) {
@@ -478,7 +477,7 @@ private fun InterviewContentDetail(
                 )
 
                 Row(
-                    modifier = Modifier.clickable { onClickOriginArticle() },
+                    modifier = Modifier.clickable { onClickOriginArticle(interview.originalNo) },
                     verticalAlignment = Alignment.CenterVertically,
                     horizontalArrangement = Arrangement.spacedBy(4.dp, Alignment.CenterHorizontally)
                 ) {

--- a/app/src/main/java/com/lottomate/lottomate/presentation/screen/interview/InterviewScreen.kt
+++ b/app/src/main/java/com/lottomate/lottomate/presentation/screen/interview/InterviewScreen.kt
@@ -1,11 +1,12 @@
 package com.lottomate.lottomate.presentation.screen.interview
 
+import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.gestures.detectTransformGestures
 import androidx.compose.foundation.gestures.rememberTransformableState
 import androidx.compose.foundation.gestures.transformable
-import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -19,14 +20,17 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.wrapContentHeight
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyListState
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.rememberPagerState
-import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Card
-import androidx.compose.material3.Divider
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
@@ -46,14 +50,15 @@ import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import coil.compose.AsyncImage
+import coil.compose.SubcomposeAsyncImage
 import coil.request.ImageRequest
+import coil.size.Scale
 import com.lottomate.lottomate.R
 import com.lottomate.lottomate.data.error.LottoMateErrorType
 import com.lottomate.lottomate.presentation.component.BannerCard
@@ -62,8 +67,9 @@ import com.lottomate.lottomate.presentation.component.LottoMateIconButton
 import com.lottomate.lottomate.presentation.component.LottoMateText
 import com.lottomate.lottomate.presentation.component.LottoMateTopAppBar
 import com.lottomate.lottomate.presentation.res.Dimens
+import com.lottomate.lottomate.presentation.screen.interview.model.InterviewDetailUiModel
 import com.lottomate.lottomate.presentation.screen.interview.model.InterviewQnA
-import com.lottomate.lottomate.presentation.screen.interview.model.InterviewUIModel
+import com.lottomate.lottomate.presentation.screen.interview.model.InterviewUiModel
 import com.lottomate.lottomate.presentation.ui.LottoMateBlack
 import com.lottomate.lottomate.presentation.ui.LottoMateDim2
 import com.lottomate.lottomate.presentation.ui.LottoMateGray100
@@ -87,23 +93,29 @@ fun InterviewRoute(
     onBackPressed: () -> Unit,
 ) {
     LaunchedEffect(Unit) {
-        vm.getInterview(no)
+        vm.getInterview(no, place)
     }
 
-    val interviewUiState by vm.interview.collectAsStateWithLifecycle()
-    val winnerInterviewsUiState by vm.winnerInterviews.collectAsStateWithLifecycle()
+    val scrollState = rememberLazyListState()
+    val uiState by vm.state.collectAsStateWithLifecycle()
 
     LaunchedEffect(true) {
         vm.errorFlow.collectLatest{ error -> onShowErrorSnackBar(error) }
     }
 
+    LaunchedEffect(uiState) {
+        if (uiState is InterviewUiState.Success) {
+            scrollState.animateScrollToItem(0)
+        }
+    }
+
     InterviewScreen(
-        interviewUiState = interviewUiState,
-        winnerInterviewsUiState = winnerInterviewsUiState,
+        uiState = uiState,
+        scrollState = scrollState,
         onBackPressed = onBackPressed,
         onClickBanner = onClickBanner,
-        onClickWinnerInterview = {
-
+        onClickWinnerInterview = { no, place ->
+            vm.getInterview(no, place)
         },
         onClickOriginArticle = {
 
@@ -113,11 +125,11 @@ fun InterviewRoute(
 
 @Composable
 private fun InterviewScreen(
-    interviewUiState: InterviewUiState<InterviewUIModel>,
-    winnerInterviewsUiState: InterviewUiState<List<InterviewUIModel>>,
+    uiState: InterviewUiState,
+    scrollState: LazyListState,
     onBackPressed: () -> Unit,
     onClickBanner: () -> Unit,
-    onClickWinnerInterview: () -> Unit,
+    onClickWinnerInterview: (Int, String) -> Unit,
     onClickOriginArticle: () -> Unit,
 ) {
     var showInterviewImage by remember { mutableStateOf(false) }
@@ -128,64 +140,64 @@ private fun InterviewScreen(
             .fillMaxSize()
             .background(LottoMateWhite),
     ) {
-        Column(
-            modifier = Modifier.verticalScroll(rememberScrollState())
+        LazyColumn(
+            modifier = Modifier.fillMaxSize(),
+            state = scrollState,
         ) {
-            Spacer(modifier = Modifier.height(Dimens.BaseTopPadding))
-            when (interviewUiState) {
-                InterviewUiState.Loading -> {
-                    // TODO : Interview Screen loading
-                }
+            item { Spacer(modifier = Modifier.height(Dimens.BaseTopPadding)) }
+
+            when (uiState) {
+                InterviewUiState.Loading -> {}
                 is InterviewUiState.Success -> {
-                    val interview = interviewUiState.data
+                    val interview = uiState.interview
+                    val interviews = uiState.interviews
 
-                    Spacer(modifier = Modifier.height(12.dp))
+                    item { Spacer(modifier = Modifier.height(12.dp)) }
 
-                    InterviewContentDetail(
-                        modifier = Modifier.fillMaxWidth(),
-                        interview = interview,
-                        onClickOriginArticle = onClickOriginArticle,
-                        onClickInterviewImage = {
-                            showInterviewImageIndex = it
-                            showInterviewImage = true
-                        },
-                    )
+                    item {
+                        InterviewContentDetail(
+                            modifier = Modifier.fillMaxWidth(),
+                            interview = interview,
+                            onClickOriginArticle = onClickOriginArticle,
+                            onClickInterviewImage = {
+                                showInterviewImageIndex = it
+                                showInterviewImage = true
+                            },
+                        )
+                    }
+
+                    item {
+                        HorizontalDivider(
+                            modifier = Modifier
+                                .padding(top = 32.dp)
+                                .fillMaxWidth(),
+                            thickness = 10.dp,
+                            color = LottoMateGray20
+                        )
+                    }
+
+                    item {
+                        BottomInterviewListContent(
+                            modifier = Modifier.fillMaxWidth(),
+                            interviewList = interviews,
+                            onClickInterviewItem = onClickWinnerInterview,
+                        )
+                    }
+
+                    item { Spacer(modifier = Modifier.height(40.dp)) }
+
+                    item {
+                        BannerCard(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(horizontal = 20.dp),
+                            onClickBanner = onClickBanner
+                        )
+                    }
+
+                    item { Spacer(modifier = Modifier.height(60.dp)) }
                 }
             }
-
-            Divider(
-                modifier = Modifier
-                    .padding(top = 32.dp)
-                    .fillMaxWidth(),
-                thickness = 10.dp,
-                color = LottoMateGray20
-            )
-
-            when (winnerInterviewsUiState) {
-                InterviewUiState.Loading -> {
-                    // TODO : Interview Screen loading
-                }
-                is InterviewUiState.Success -> {
-                    val interviews = winnerInterviewsUiState.data
-
-                    BottomInterviewListContent(
-                        modifier = Modifier.fillMaxWidth(),
-                        interviewList = interviews,
-                        onClickInterviewItem = onClickWinnerInterview,
-                    )
-                }
-            }
-
-            Spacer(modifier = Modifier.height(40.dp))
-
-            BannerCard(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(horizontal = 20.dp),
-                onClickBanner = onClickBanner
-            )
-
-            Spacer(modifier = Modifier.height(60.dp))
         }
 
         LottoMateTopAppBar(
@@ -197,10 +209,8 @@ private fun InterviewScreen(
         if (showInterviewImage) {
             InterviewImageView(
                 index = showInterviewImageIndex,
-                images = (interviewUiState as InterviewUiState.Success).data.imgs,
-                onDismiss = {
-                    showInterviewImage = false
-                },
+                images = (uiState as InterviewUiState.Success).interview.imgs,
+                onDismiss = { showInterviewImage = false },
             )
         }
     }
@@ -408,7 +418,7 @@ private fun InterviewImageView(
 @Composable
 private fun InterviewContentDetail(
     modifier: Modifier = Modifier,
-    interview: InterviewUIModel,
+    interview: InterviewDetailUiModel,
     onClickOriginArticle: () -> Unit,
     onClickInterviewImage: (Int) -> Unit,
 ) {
@@ -443,31 +453,34 @@ private fun InterviewContentDetail(
                 .fillMaxWidth()
                 .padding(horizontal = Dimens.DefaultPadding20)
         ) {
-            interview.contents.forEachIndexed { index, qna ->
-                InterviewContentQnA(
-                    question = qna.question,
-                    answer = qna.answer,
-                )
-
-                if (index != interview.contents.lastIndex) Spacer(modifier = Modifier.height(28.dp))
+            Column(
+                verticalArrangement = Arrangement.spacedBy(28.dp)
+            ) {
+                interview.contents.forEach { qna ->
+                    InterviewContentQnA(
+                        question = qna.question,
+                        answer = qna.answer,
+                    )
+                }
             }
 
             Spacer(modifier = Modifier.height(16.dp))
 
             Row(
+                modifier = Modifier.fillMaxWidth(),
                 horizontalArrangement = Arrangement.SpaceBetween,
                 verticalAlignment = Alignment.CenterVertically,
-                modifier = Modifier.fillMaxWidth()
             ) {
                 LottoMateText(
                     text = stringResource(id = R.string.interview_content_bottom_notice),
                     style = LottoMateTheme.typography.caption
-                        .copy(color = LottoMateGray80)
+                        .copy(color = LottoMateGray80),
                 )
 
                 Row(
+                    modifier = Modifier.clickable { onClickOriginArticle() },
                     verticalAlignment = Alignment.CenterVertically,
-                    modifier = Modifier.noInteractionClickable { onClickOriginArticle() }
+                    horizontalArrangement = Arrangement.spacedBy(4.dp, Alignment.CenterHorizontally)
                 ) {
                     LottoMateText(
                         text = "원문 보러가기",
@@ -478,9 +491,8 @@ private fun InterviewContentDetail(
                     Icon(
                         painter = painterResource(id = R.drawable.icon_arrow_right),
                         contentDescription = "",
-                        modifier = Modifier
-                            .padding(start = 4.dp)
-                            .size(14.dp)
+                        tint = LottoMateGray100,
+                        modifier = Modifier.size(14.dp),
                     )
                 }
             }
@@ -491,41 +503,45 @@ private fun InterviewContentDetail(
 @Composable
 private fun InterviewTitle(
     modifier: Modifier = Modifier,
-    interview: InterviewUIModel,
+    interview: InterviewDetailUiModel,
 ) {
-    Column(modifier = modifier) {
+    Column(
+        modifier = modifier,
+        verticalArrangement = Arrangement.spacedBy(4.dp)
+    ) {
         Row(verticalAlignment = Alignment.CenterVertically) {
             LottoMateText(
-                text = "${interview.lottoRound}회차",
+                text = interview.place,
                 style = LottoMateTheme.typography.caption
                     .copy(color = LottoMateGray120)
             )
             
-            LottoMateText(
-                text = "|",
-                textAlign = TextAlign.Center,
-                style = LottoMateTheme.typography.caption
-                    .copy(color = LottoMateGray120),
-                modifier = Modifier.padding(start = 4.dp),
-            )
+//            LottoMateText(
+//                text = "|",
+//                textAlign = TextAlign.Center,
+//                style = LottoMateTheme.typography.caption
+//                    .copy(color = LottoMateGray120),
+//                modifier = Modifier.padding(start = 4.dp),
+//            )
 
-            LottoMateText(
-//                text = "${interview.subTitle} ${if (interview.lottoPrize % 10 == 0.0) Math.round(interview.lottoPrize) else interview.lottoPrize}억",
-                text = "",
-                style = LottoMateTheme.typography.caption
-                    .copy(color = LottoMateGray120),
-                modifier = Modifier.padding(start = 4.dp),
-            )
+//            LottoMateText(
+////                text = "${interview.subTitle} ${if (interview.lottoPrize % 10 == 0.0) Math.round(interview.lottoPrize) else interview.lottoPrize}억",
+//                text = "",
+//                style = LottoMateTheme.typography.caption
+//                    .copy(color = LottoMateGray120),
+//                modifier = Modifier.padding(start = 4.dp),
+//            )
         }
 
         LottoMateText(
             text = interview.title,
-            style = LottoMateTheme.typography.title3
+            style = LottoMateTheme.typography.title3,
         )
 
         Row(
             modifier = Modifier.padding(top = 4.dp),
             verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(8.dp, Alignment.CenterHorizontally),
         ) {
             LottoMateText(
                 text = "인터뷰 ${interview.interviewDate}",
@@ -535,16 +551,14 @@ private fun InterviewTitle(
 
             LottoMateText(
                 text = "|",
-                style = LottoMateTheme.typography.caption
+                style = LottoMateTheme.typography.caption2
                     .copy(color = LottoMateGray80),
-                modifier = Modifier.padding(start = 8.dp)
             )
 
             LottoMateText(
                 text = "작성 ${interview.uploadDate}",
                 style = LottoMateTheme.typography.caption2
                     .copy(color = LottoMateGray80),
-                modifier = Modifier.padding(start = 8.dp),
             )
         }
     }
@@ -556,16 +570,20 @@ private fun InterviewContentQnA(
     question: String,
     answer: String,
 ) {
-    Column(modifier = modifier) {
+    Column(
+        modifier = modifier,
+        verticalArrangement = Arrangement.spacedBy(8.dp)
+    ) {
         LottoMateText(
             text = "Q. $question",
-            style = LottoMateTheme.typography.headline2,
+            style = LottoMateTheme.typography.headline2
+                .copy(color = LottoMateBlack),
         )
 
         LottoMateText(
             text = answer,
-            style = LottoMateTheme.typography.body1,
-            modifier = Modifier.padding(top = 8.dp),
+            style = LottoMateTheme.typography.body1
+                .copy(color = LottoMateBlack),
         )
     }
 }
@@ -573,19 +591,19 @@ private fun InterviewContentQnA(
 @Composable
 private fun BottomInterviewListContent(
     modifier: Modifier = Modifier,
-    interviewList: List<InterviewUIModel>,
-    onClickInterviewItem: () -> Unit,
+    interviewList: List<InterviewUiModel>,
+    onClickInterviewItem: (Int, String) -> Unit,
 ) {
     Column(modifier = modifier) {
         Column(
             modifier = Modifier
-                .padding(horizontal = 20.dp)
+                .padding(horizontal = Dimens.DefaultPadding20)
                 .padding(top = 24.dp)
         ) {
             LottoMateText(
                 text = "로또 당첨자 후기",
                 style = LottoMateTheme.typography.headline1
-                    .copy(color = LottoMateGray120)
+                    .copy(color = LottoMateBlack),
             )
 
             LottoMateText(
@@ -597,23 +615,19 @@ private fun BottomInterviewListContent(
 
         Spacer(modifier = Modifier.height(24.dp))
 
-        Row(
-            modifier = Modifier
-                .fillMaxWidth()
-                .horizontalScroll(rememberScrollState())
+        LazyRow(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.spacedBy(16.dp, Alignment.CenterHorizontally),
+            contentPadding = PaddingValues(horizontal = 20.dp),
         ) {
-            repeat(5) {
-                if (it == 0) Spacer(modifier = Modifier.width(20.dp))
-
+            items(
+                items = interviewList,
+                key = { it.no }
+            ) {interview ->
                 BottomInterviewListItem(
-                    title = interviewList[it].title,
-                    thumb = interviewList[it].thumb,
-                    interviewDate = interviewList[it].interviewDate,
-                    onClick = onClickInterviewItem
+                    interview = interview,
+                    onClick = { onClickInterviewItem(interview.no, interview.place) },
                 )
-
-                if (it != 4) Spacer(modifier = Modifier.width(16.dp))
-                else Spacer(modifier = Modifier.width(20.dp))
             }
         }
     }
@@ -622,21 +636,26 @@ private fun BottomInterviewListContent(
 @Composable
 private fun BottomInterviewListItem(
     modifier: Modifier = Modifier,
-    title: String,
-    subTitle: String = "",
-    thumb: String,
-    interviewDate: String,
+    interview: InterviewUiModel,
     onClick: () -> Unit,
 ) {
+    val context = LocalContext.current
     LottoMateCard(
         modifier = modifier.size(width = 220.dp, height = 202.dp),
         onClick = onClick,
     ) {
         Column(modifier = Modifier.fillMaxWidth()) {
-            AsyncImage(
-                model = R.drawable.img_review,
-                contentDescription = "",
-                placeholder = painterResource(id = R.drawable.img_review),
+            SubcomposeAsyncImage(
+                model = ImageRequest.Builder(context).apply {
+                    data(interview.thumbs)
+                    size(600)
+                    scale(Scale.FILL)
+                }
+                    .build(),
+                contentDescription = "interview thumbnail image",
+                error = {
+                    Image(painter = painterResource(id = R.drawable.img_interview_empty01), contentDescription = "interview Thumbnail error")
+                },
                 modifier = Modifier
                     .fillMaxWidth()
                     .height(100.dp),
@@ -650,20 +669,21 @@ private fun BottomInterviewListItem(
             ) {
                 Column {
                     LottoMateText(
-                        text = subTitle,
+                        text = interview.place,
                         style = LottoMateTheme.typography.caption
                             .copy(color = LottoMateGray80)
                     )
                     LottoMateText(
-                        text = title,
-                        style = LottoMateTheme.typography.label2,
+                        text = interview.title,
+                        style = LottoMateTheme.typography.label2
+                            .copy(color = LottoMateBlack),
                         maxLines = 2,
                         overflow = TextOverflow.Ellipsis,
                     )
                 }
 
                 LottoMateText(
-                    text = interviewDate,
+                    text = interview.date,
                     style = LottoMateTheme.typography.caption2
                         .copy(color = LottoMateGray80),
                     modifier = Modifier.align(Alignment.BottomStart)
@@ -673,41 +693,61 @@ private fun BottomInterviewListItem(
     }
 }
 
-@Preview(showBackground = true)
-@Composable
-private fun InterviewImageSectionPreview() {
-    LottoMateTheme {
-        InterviewScreen(
-            interviewUiState = InterviewUiState.Success(InterviewMockData),
-            winnerInterviewsUiState = InterviewUiState.Success(List(5) { InterviewMockData }),
-            onBackPressed = {},
-            onClickBanner = {},
-            onClickWinnerInterview = {},
-            onClickOriginArticle = {}
-        )
-    }
-}
-
-@Preview(showBackground = true)
+@Preview(showBackground = true, heightDp = 1500)
 @Composable
 private fun InterviewPreview() {
     LottoMateTheme {
         InterviewScreen(
-            interviewUiState = InterviewUiState.Success(InterviewMockData.copy(title = "만약두줄이넘어가면세로로내려가야하는거겠죠그럼만약에세줄까지나오는경우가있을까요설마", imgs = emptyList())),
-            winnerInterviewsUiState = InterviewUiState.Success(List(5) { InterviewMockData }),
+            uiState = InterviewUiState.Success(InterviewMockData, InterviewsMockDate),
+            scrollState = rememberLazyListState(),
             onBackPressed = {},
             onClickBanner = {},
-            onClickWinnerInterview = {},
+            onClickWinnerInterview = { _, _ -> },
             onClickOriginArticle = {}
         )
     }
 }
 
-val InterviewMockData = InterviewUIModel(
+@Preview(showBackground = true)
+@Composable
+private fun LongTitleInterviewPreview() {
+    LottoMateTheme {
+        InterviewScreen(
+            uiState = InterviewUiState.Success(
+                InterviewMockData.copy(
+                    title = "일이삼사오육칠팔구십일이삼사오육칠팔구십일이삼사오육칠팔구십일이"
+                ),
+                InterviewsMockDate,
+            ),
+            scrollState = rememberLazyListState(),
+            onBackPressed = {},
+            onClickBanner = {},
+            onClickWinnerInterview = { _, _ -> },
+            onClickOriginArticle = {}
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun InterviewEmptyImagePreview() {
+    LottoMateTheme {
+        InterviewScreen(
+            uiState = InterviewUiState.Success(InterviewMockData.copy(imgs = emptyList()), InterviewsMockDate),
+            scrollState = rememberLazyListState(),
+            onBackPressed = {},
+            onClickBanner = {},
+            onClickWinnerInterview = { _, _ -> },
+            onClickOriginArticle = {}
+        )
+    }
+}
+
+val InterviewMockData = InterviewDetailUiModel(
     no = 20,
     title = "스피또 1등은 아버지의 성실함 덕분!",
-    interviewDate = "2017-04-14",
-    uploadDate = "2017-04-14",
+    interviewDate = "2017.04.14",
+    uploadDate = "2017.04.14",
     thumb = "https://lottomate-review.s3.ap-northeast-2.amazonaws.com/13406_1.jpg",
     imgs = listOf(
         "https://lottomate-review.s3.ap-northeast-2.amazonaws.com/13406_1.jpg",
@@ -736,4 +776,15 @@ val InterviewMockData = InterviewUIModel(
         ),
     ),
     originalNo = 13406,
+    place = "스피또 500, 29회차 1등 2억"
 )
+
+val InterviewsMockDate = List(5) {
+    InterviewUiModel(
+        no = it,
+        title = "인터뷰 목록 데이터 $it",
+        thumbs = "https://lottomate-review.s3.ap-northeast-2.amazonaws.com/13406_2.jpg",
+        date = "2023.01.01",
+        place = "스피또 500, 29회차 1등 2억",
+    )
+}

--- a/app/src/main/java/com/lottomate/lottomate/presentation/screen/interview/InterviewViewModel.kt
+++ b/app/src/main/java/com/lottomate/lottomate/presentation/screen/interview/InterviewViewModel.kt
@@ -1,16 +1,18 @@
 package com.lottomate.lottomate.presentation.screen.interview
 
-import android.util.Log
 import androidx.lifecycle.viewModelScope
 import com.lottomate.lottomate.data.error.LottoMateErrorHandler
 import com.lottomate.lottomate.domain.repository.InterviewRepository
 import com.lottomate.lottomate.presentation.screen.BaseViewModel
-import com.lottomate.lottomate.presentation.screen.interview.model.InterviewUIModel
+import com.lottomate.lottomate.presentation.screen.interview.model.InterviewDetailUiModel
+import com.lottomate.lottomate.presentation.screen.interview.model.InterviewUiModel
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import javax.inject.Inject
@@ -20,29 +22,34 @@ class InterviewViewModel @Inject constructor(
     errorHandler: LottoMateErrorHandler,
     private val interviewRepository: InterviewRepository,
 ) : BaseViewModel(errorHandler){
-    private var _winnerInterviews = MutableStateFlow(InterviewUiState.Loading as InterviewUiState<List<InterviewUIModel>>)
-    private var _interview = MutableStateFlow(InterviewUiState.Loading as InterviewUiState<InterviewUIModel>)
-    val interview: StateFlow<InterviewUiState<InterviewUIModel>> get() = _interview.asStateFlow()
-    val winnerInterviews: StateFlow<InterviewUiState<List<InterviewUIModel>>> get() = _winnerInterviews.asStateFlow()
+    private var _state = MutableStateFlow<InterviewUiState>(InterviewUiState.Loading)
+    val state: StateFlow<InterviewUiState> get() = _state.asStateFlow()
+    val interviews: StateFlow<List<InterviewUiModel>> = interviewRepository.interviews
 
     fun getInterview(interviewNo: Int) {
-        runCatching {
-            viewModelScope.launch {
-                interviewRepository.fetchInterview(interviewNo)
-                    .collectLatest { collectData ->
-                        _interview.update {
-                            InterviewUiState.Success(collectData)
-                        }
-                    }
+        viewModelScope.launch {
+            combine(
+                interviewRepository.fetchInterview(interviewNo),
+                interviewRepository.interviews
+            ) { interview, interviews ->
+                InterviewUiState.Success(
+                    interview,
+                    interviews
+                )
             }
-        }.onFailure {
-            Log.d("InterviewViewModel", it.stackTraceToString())
-            handleException(it)
+                .onStart { _state.update { InterviewUiState.Loading } }
+                .catch { handleException(it) }
+                .collect { newUiState ->
+                    _state.update { newUiState }
+                }
         }
     }
 }
 
-sealed interface InterviewUiState<out T> {
-    data object Loading: InterviewUiState<Nothing>
-    data class Success<T> (val data: T): InterviewUiState<T>
+sealed interface InterviewUiState {
+    data object Loading : InterviewUiState
+    data class Success(
+        val interview: InterviewDetailUiModel,
+        val interviews: List<InterviewUiModel>,
+    ) : InterviewUiState
 }

--- a/app/src/main/java/com/lottomate/lottomate/presentation/screen/interview/InterviewViewModel.kt
+++ b/app/src/main/java/com/lottomate/lottomate/presentation/screen/interview/InterviewViewModel.kt
@@ -26,14 +26,14 @@ class InterviewViewModel @Inject constructor(
     val state: StateFlow<InterviewUiState> get() = _state.asStateFlow()
     val interviews: StateFlow<List<InterviewUiModel>> = interviewRepository.interviews
 
-    fun getInterview(interviewNo: Int) {
+    fun getInterview(interviewNo: Int, place: String) {
         viewModelScope.launch {
             combine(
                 interviewRepository.fetchInterview(interviewNo),
                 interviewRepository.interviews
             ) { interview, interviews ->
                 InterviewUiState.Success(
-                    interview,
+                    interview.copy(place = place),
                     interviews
                 )
             }

--- a/app/src/main/java/com/lottomate/lottomate/presentation/screen/interview/model/InterviewDetailUIModel.kt
+++ b/app/src/main/java/com/lottomate/lottomate/presentation/screen/interview/model/InterviewDetailUIModel.kt
@@ -14,6 +14,7 @@ data class InterviewDetailUiModel(
     val imgs: List<String>,
     val contents: List<InterviewQnA>,
     val originalNo: Int,
+    val place: String = "",
 )
 
 @Serializable

--- a/app/src/main/java/com/lottomate/lottomate/presentation/screen/interview/model/InterviewDetailUIModel.kt
+++ b/app/src/main/java/com/lottomate/lottomate/presentation/screen/interview/model/InterviewDetailUIModel.kt
@@ -3,7 +3,7 @@ package com.lottomate.lottomate.presentation.screen.interview.model
 import kotlinx.serialization.Serializable
 
 @Serializable
-data class InterviewUIModel(
+data class InterviewDetailUiModel(
     val no: Int,
     val title: String,
     val lottoRound: Int = 0,

--- a/app/src/main/java/com/lottomate/lottomate/presentation/screen/interview/model/InterviewUiModel.kt
+++ b/app/src/main/java/com/lottomate/lottomate/presentation/screen/interview/model/InterviewUiModel.kt
@@ -1,9 +1,12 @@
 package com.lottomate.lottomate.presentation.screen.interview.model
 
+import androidx.annotation.DrawableRes
+
 data class InterviewUiModel(
     val no: Int,
     val title: String,
     val thumbs: String,
+    @DrawableRes val emptyThumbs: Int,
     val date: String,
     val place: String,
 )

--- a/app/src/main/java/com/lottomate/lottomate/presentation/screen/interview/model/InterviewUiModel.kt
+++ b/app/src/main/java/com/lottomate/lottomate/presentation/screen/interview/model/InterviewUiModel.kt
@@ -1,0 +1,9 @@
+package com.lottomate.lottomate.presentation.screen.interview.model
+
+data class InterviewUiModel(
+    val no: Int,
+    val title: String,
+    val thumbs: String,
+    val date: String,
+    val place: String,
+)

--- a/app/src/main/java/com/lottomate/lottomate/presentation/screen/interview/navigation/InterviewNavigation.kt
+++ b/app/src/main/java/com/lottomate/lottomate/presentation/screen/interview/navigation/InterviewNavigation.kt
@@ -1,0 +1,54 @@
+package com.lottomate.lottomate.presentation.screen.interview.navigation
+
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.navigation.NavController
+import androidx.navigation.NavGraphBuilder
+import androidx.navigation.compose.composable
+import androidx.navigation.toRoute
+import com.lottomate.lottomate.R
+import com.lottomate.lottomate.data.error.LottoMateErrorType
+import com.lottomate.lottomate.presentation.component.BannerType
+import com.lottomate.lottomate.presentation.component.LottoMateBasicWebView
+import com.lottomate.lottomate.presentation.navigation.LottoMateRoute
+import com.lottomate.lottomate.presentation.screen.home.navigation.navigateToBanner
+import com.lottomate.lottomate.presentation.screen.interview.InterviewRoute
+
+fun NavController.navigateToInterviewDetail(no: Int, place: String) {
+    navigate(LottoMateRoute.InterviewDetail(no, place))
+}
+
+fun NavController.navigateToOriginalInterview(no: Int) {
+    navigate(LottoMateRoute.OriginalInterview(no))
+}
+
+fun NavGraphBuilder.interviewNavGraph(
+    padding: PaddingValues,
+    navController: NavController,
+    onShowErrorSnackBar: (errorType: LottoMateErrorType) -> Unit,
+) {
+    // 인터뷰 상세 화면
+    composable<LottoMateRoute.InterviewDetail> { navBackStackEntry ->
+        val no = navBackStackEntry.toRoute<LottoMateRoute.InterviewDetail>().no
+        val place = navBackStackEntry.toRoute<LottoMateRoute.InterviewDetail>().place
+
+        InterviewRoute(
+            no = no,
+            place = place,
+            moveToOriginalInterview = { navController.navigateToOriginalInterview(it) },
+            onClickBanner = { navController.navigateToBanner(BannerType.MAP) },
+            onShowErrorSnackBar = onShowErrorSnackBar,
+            onBackPressed = { navController.navigateUp() },
+        )
+    }
+
+    // 동행복권 당첨자 후기 화면
+    composable<LottoMateRoute.OriginalInterview> {navBackStackEntry ->
+        val no = navBackStackEntry.toRoute<LottoMateRoute.OriginalInterview>().no
+
+        LottoMateBasicWebView(
+            title = R.string.top_app_bar_empty_title,
+            url = "https://m.dhlottery.co.kr/gameResult.do?method=highWinView&txtNo=$no",
+            onBackPressed = { navController.navigateUp() },
+        )
+    }
+}

--- a/app/src/main/java/com/lottomate/lottomate/presentation/screen/lounge/LoungeScreen.kt
+++ b/app/src/main/java/com/lottomate/lottomate/presentation/screen/lounge/LoungeScreen.kt
@@ -23,10 +23,12 @@ import androidx.compose.material3.Icon
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.imageResource
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
@@ -35,16 +37,19 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import coil.compose.AsyncImage
+import coil.compose.SubcomposeAsyncImage
+import coil.request.ImageRequest
+import coil.size.Scale
 import com.lottomate.lottomate.R
 import com.lottomate.lottomate.data.error.LottoMateErrorType
-import com.lottomate.lottomate.data.remote.response.interview.ResponseInterviewsInfo
 import com.lottomate.lottomate.presentation.component.BannerCard
 import com.lottomate.lottomate.presentation.component.BannerType
 import com.lottomate.lottomate.presentation.component.LottoMateCard
 import com.lottomate.lottomate.presentation.component.LottoMateText
 import com.lottomate.lottomate.presentation.component.LottoMateTopAppBar
 import com.lottomate.lottomate.presentation.res.Dimens
+import com.lottomate.lottomate.presentation.screen.interview.InterviewsMockData
+import com.lottomate.lottomate.presentation.screen.interview.model.InterviewUiModel
 import com.lottomate.lottomate.presentation.ui.LottoMateBlack
 import com.lottomate.lottomate.presentation.ui.LottoMateGray100
 import com.lottomate.lottomate.presentation.ui.LottoMateGray80
@@ -82,7 +87,7 @@ fun LoungeRoute(
 @Composable
 private fun LoungeScreen(
     modifier: Modifier = Modifier,
-    interviews: List<ResponseInterviewsInfo>,
+    interviews: List<InterviewUiModel>,
     onClickSetting: () -> Unit,
     onClickTopBanner: () -> Unit,
     onClickBottomBanner: (BannerType) -> Unit,
@@ -141,7 +146,7 @@ private fun LoungeScreen(
 @Composable
 private fun InterviewSection(
     modifier: Modifier = Modifier,
-    interviews: List<ResponseInterviewsInfo>,
+    interviews: List<InterviewUiModel>,
     onClickInterview: (Int, String) -> Unit,
 ) {
     val pagerState = rememberPagerState {
@@ -149,10 +154,11 @@ private fun InterviewSection(
     }
 
     Column(
-        modifier = modifier,
+        modifier = modifier.fillMaxWidth(),
     ) {
         Column(
             modifier = Modifier.padding(horizontal = Dimens.DefaultPadding20),
+            verticalArrangement = Arrangement.spacedBy(2.dp, Alignment.CenterVertically)
         ) {
             LottoMateText(
                 text = stringResource(id = R.string.lounge_interview_text_sub_title),
@@ -162,8 +168,8 @@ private fun InterviewSection(
 
             LottoMateText(
                 text = stringResource(id = R.string.lounge_interview_text_title),
-                style = LottoMateTheme.typography.title3,
-                modifier = Modifier.padding(top = 2.dp),
+                style = LottoMateTheme.typography.title3
+                    .copy(color = LottoMateBlack),
             )
         }
 
@@ -174,11 +180,8 @@ private fun InterviewSection(
             modifier = Modifier.padding(top = 20.dp),
         ) {page ->
             InterviewItem(
-                title = interviews[page].reviewTitle,
-                subTitle = interviews[page].reviewPlace,
-                thumb = interviews[page].reviewThumb,
-                interviewDate = interviews[page].intrvDate,
-                onClick = { onClickInterview(interviews[page].reviewNo, interviews[page].reviewPlace) },
+                interview = interviews[page],
+                onClick = { onClickInterview(interviews[page].no, interviews[page].place) },
             )
         }
 
@@ -208,26 +211,46 @@ private fun InterviewSection(
 @Composable
 private fun InterviewItem(
     modifier: Modifier = Modifier,
-    title: String,
-    subTitle: String,
-    thumb: String,
-    interviewDate: String,
+    interview: InterviewUiModel,
     onClick: () -> Unit,
 ) {
+    val context = LocalContext.current
+
     LottoMateCard(
         modifier = modifier.size(width = 220.dp, height = 202.dp),
         onClick = onClick,
     ) {
         Column(modifier = Modifier.fillMaxWidth()) {
-            AsyncImage(
-                model = R.drawable.img_review,
-                contentDescription = "",
-                placeholder = painterResource(id = R.drawable.img_review),
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .height(100.dp),
-                contentScale = ContentScale.Crop
-            )
+            if (interview.thumbs.isNotEmpty()) {
+                Image(
+                    painter = painterResource(id = interview.emptyThumbs),
+                    contentDescription = "interview thumbnail image empty",
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(100.dp),
+                )
+            } else {
+                SubcomposeAsyncImage(
+                    model = ImageRequest.Builder(context).apply {
+                        data(interview.thumbs)
+                        size(600)
+                        scale(Scale.FILL)
+                    }
+                        .build(),
+                    contentDescription = "interview thumbnail image",
+                    error = {
+                        Image(
+                            painter = painterResource(id = interview.emptyThumbs),
+                            contentDescription = "interview Thumbnail error",
+                        )
+                    },
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(100.dp),
+                    contentScale = ContentScale.Crop
+                )
+            }
+
 
             Column(
                 modifier = Modifier
@@ -235,13 +258,13 @@ private fun InterviewItem(
                     .padding(horizontal = 16.dp, vertical = 12.dp)
             ) {
                 LottoMateText(
-                    text = subTitle,
+                    text = interview.place,
                     style = LottoMateTheme.typography.caption
-                        .copy(color = LottoMateGray80)
+                        .copy(color = LottoMateGray80),
                 )
 
                 LottoMateText(
-                    text = title,
+                    text = interview.title,
                     style = LottoMateTheme.typography.label2,
                     maxLines = 2,
                     minLines = 2,
@@ -250,7 +273,7 @@ private fun InterviewItem(
                 )
 
                 LottoMateText(
-                    text = interviewDate.replace("-", "."),
+                    text = interview.date,
                     style = LottoMateTheme.typography.caption2
                         .copy(color = LottoMateGray80),
                 )
@@ -264,18 +287,7 @@ private fun InterviewItem(
 private fun LoungeScreenPreview() {
     LottoMateTheme {
         LoungeScreen(
-            interviews = listOf(
-                ResponseInterviewsInfo(1, 1001, "First Interview", "https://example.com/thumb1.jpg", "2024-01-01", "Seoul"),
-                ResponseInterviewsInfo(2, 1002, "Second Interview", "https://example.com/thumb2.jpg", "2024-01-08", "Busan"),
-                ResponseInterviewsInfo(3, 1003, "Third Interview", "https://example.com/thumb3.jpg", "2024-01-15", "Incheon"),
-                ResponseInterviewsInfo(4, 1004, "Fourth Interview", "https://example.com/thumb4.jpg", "2024-01-22", "Daegu"),
-                ResponseInterviewsInfo(5, 1005, "Fifth Interview", "https://example.com/thumb5.jpg", "2024-01-29", "Daejeon"),
-                ResponseInterviewsInfo(6, 1006, "Sixth Interview", "https://example.com/thumb6.jpg", "2024-02-05", "Gwangju"),
-                ResponseInterviewsInfo(7, 1007, "Seventh Interview", "https://example.com/thumb7.jpg", "2024-02-12", "Suwon"),
-                ResponseInterviewsInfo(8, 1008, "Eighth Interview", "https://example.com/thumb8.jpg", "2024-02-19", "Ulsan"),
-                ResponseInterviewsInfo(9, 1009, "Ninth Interview", "https://example.com/thumb9.jpg", "2024-02-26", "Jeju"),
-                ResponseInterviewsInfo(10, 1010, "Tenth Interview", "https://example.com/thumb10.jpg", "2024-03-04", "Cheongju")
-            ),
+            interviews = InterviewsMockData,
             onClickTopBanner = {},
             onClickSetting = {},
             onClickBottomBanner = {},

--- a/app/src/main/java/com/lottomate/lottomate/presentation/screen/lounge/LoungeViewModel.kt
+++ b/app/src/main/java/com/lottomate/lottomate/presentation/screen/lounge/LoungeViewModel.kt
@@ -1,20 +1,11 @@
 package com.lottomate.lottomate.presentation.screen.lounge
 
-import androidx.lifecycle.viewModelScope
 import com.lottomate.lottomate.data.error.LottoMateErrorHandler
-import com.lottomate.lottomate.data.remote.response.interview.ResponseInterviewsInfo
 import com.lottomate.lottomate.domain.repository.InterviewRepository
 import com.lottomate.lottomate.presentation.screen.BaseViewModel
+import com.lottomate.lottomate.presentation.screen.interview.model.InterviewUiModel
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.flow.catch
-import kotlinx.coroutines.flow.collectLatest
-import kotlinx.coroutines.flow.update
-import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
 import javax.inject.Inject
 
 @HiltViewModel
@@ -22,40 +13,5 @@ class LoungeViewModel @Inject constructor(
     errorHandler: LottoMateErrorHandler,
     private val interviewRepository: InterviewRepository,
 ) : BaseViewModel(errorHandler) {
-
-    private var _interviews = MutableStateFlow<List<ResponseInterviewsInfo>>(emptyList())
-    val interviews: StateFlow<List<ResponseInterviewsInfo>> get() = _interviews.asStateFlow()
-
-    init {
-        loadInterviews()
-    }
-
-    private fun loadInterviews() {
-        viewModelScope.launch {
-            runCatching {
-                val interviewNumbers = getInterviewNumbers()
-
-                interviewRepository.fetchInterviews(interviewNumbers)
-                    .catch { handleException(it) }
-                    .collectLatest { collectData ->
-                        _interviews.update { collectData }
-                    }
-            }.onFailure { handleException(it) }
-        }
-    }
-
-    /**
-     * 최신 인터뷰 회차를 가져온 후, 이전 인터뷰 5회차 리스트를 생성합니다.
-     *
-     * @return 이전 인터뷰 5회차 리스트
-     */
-    private suspend fun getInterviewNumbers(): List<Int> {
-        val latestInterviewNo = withContext(Dispatchers.IO) {
-            interviewRepository.fetchLatestNoOfInterview()
-        }
-
-        return (latestInterviewNo downTo (latestInterviewNo - 5 + 1))
-            .toList()
-            .sorted()
-    }
+    val interviews: StateFlow<List<InterviewUiModel>> = interviewRepository.interviews
 }

--- a/app/src/main/java/com/lottomate/lottomate/presentation/screen/lounge/navigation/LoungeNavigation.kt
+++ b/app/src/main/java/com/lottomate/lottomate/presentation/screen/lounge/navigation/LoungeNavigation.kt
@@ -8,7 +8,7 @@ import androidx.navigation.compose.composable
 import com.lottomate.lottomate.data.error.LottoMateErrorType
 import com.lottomate.lottomate.presentation.navigation.BottomTabRoute
 import com.lottomate.lottomate.presentation.screen.home.navigation.navigateToBanner
-import com.lottomate.lottomate.presentation.screen.home.navigation.navigateToInterviewDetail
+import com.lottomate.lottomate.presentation.screen.interview.navigation.navigateToInterviewDetail
 import com.lottomate.lottomate.presentation.screen.lounge.LoungeRoute
 import com.lottomate.lottomate.presentation.screen.setting.navigation.navigateToSetting
 

--- a/app/src/main/java/com/lottomate/lottomate/presentation/screen/main/MainNavHost.kt
+++ b/app/src/main/java/com/lottomate/lottomate/presentation/screen/main/MainNavHost.kt
@@ -5,10 +5,10 @@ import androidx.compose.runtime.Composable
 import androidx.navigation.compose.NavHost
 import com.lottomate.lottomate.data.error.LottoMateErrorType
 import com.lottomate.lottomate.presentation.screen.home.navigation.homeNavGraph
+import com.lottomate.lottomate.presentation.screen.interview.navigation.interviewNavGraph
 import com.lottomate.lottomate.presentation.screen.intro.navigation.introNavGraph
 import com.lottomate.lottomate.presentation.screen.login.navigation.loginNavGraph
 import com.lottomate.lottomate.presentation.screen.lounge.navigation.loungeNavGraph
-import com.lottomate.lottomate.presentation.screen.main.model.FullScreenType
 import com.lottomate.lottomate.presentation.screen.map.navigation.mapNavGraph
 import com.lottomate.lottomate.presentation.screen.pocket.navigation.pocketNavGraph
 import com.lottomate.lottomate.presentation.screen.setting.navigation.settingNavGraph
@@ -48,6 +48,12 @@ fun MainNavHost(
         )
 
         loungeNavGraph(
+            padding = padding,
+            navController = navigator.navController,
+            onShowErrorSnackBar = onShowErrorSnackBar,
+        )
+
+        interviewNavGraph(
             padding = padding,
             navController = navigator.navController,
             onShowErrorSnackBar = onShowErrorSnackBar,

--- a/app/src/main/java/com/lottomate/lottomate/presentation/ui/Type.kt
+++ b/app/src/main/java/com/lottomate/lottomate/presentation/ui/Type.kt
@@ -128,7 +128,7 @@ private val caption = pretendardStyle.copy(
 )
 
 private val caption2 = pretendardStyle.copy(
-    fontWeight = FontWeight.Medium,
+    fontWeight = FontWeight.Normal,
     fontSize = 10.sp,
 //    lineHeight = 16.sp,
     lineHeight = 14.sp,

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -72,7 +72,7 @@
 
     <!-- 로또 당첨 후기 -->
     <string name="top_app_bar_empty_title"></string>
-    <string name="interview_content_bottom_notice">오늘 본 글은 내일 다시 확인할 수 있어요.</string>
+    <string name="interview_content_bottom_notice">오늘 본 글은 내일 다시 확인할 수 있어요</string>
     <string name="interview_exam_question">당첨되신 걸 어떻게 알게 되셨고, 또 알았을 때 기분이 어떠셨나요?</string>
     <string name="interview_exam_answer">복권 당첨 후기 이벤트 멘트 작성 예정입니다. 질문에 대한 답변입니다. 나도 당첨되고 싶다. 저희 모두 당첨되게 해주세요. 신축 빌라 갖고 싶당.</string>
 

--- a/app/src/test/java/com/lottomate/lottomate/manager/FakeInterviewViewManager.kt
+++ b/app/src/test/java/com/lottomate/lottomate/manager/FakeInterviewViewManager.kt
@@ -1,0 +1,50 @@
+package com.lottomate.lottomate.manager
+
+import com.lottomate.lottomate.data.manager.InterviewViewManager
+import com.lottomate.lottomate.data.model.InterviewViewEntity
+import com.lottomate.lottomate.utils.DateUtils
+
+class FakeInterviewViewManager(
+    private var today: String = DateUtils.getCurrentDate()
+) : InterviewViewManager {
+    private var viewedData = InterviewViewEntity(
+        date = today,
+        interviewIds = mutableSetOf()
+    )
+
+    override suspend fun addInterviewId(id: Int) {
+        refreshIfDateChanged()
+        viewedData = viewedData.copy(
+            interviewIds = viewedData.interviewIds + id
+        )
+    }
+
+    override suspend fun getUnviewedInterviewIds(latestInterviewId: Int): List<Int> {
+        refreshIfDateChanged()
+
+        val unviewed = (latestInterviewId downTo 1)
+            .filterNot { viewedData.interviewIds.contains(it) }
+
+        if (unviewed.isEmpty()) {
+            viewedData = viewedData.copy(interviewIds = mutableSetOf())
+        }
+
+        return (latestInterviewId downTo 1)
+            .filterNot { viewedData.interviewIds.contains(it) }
+            .take(5)
+    }
+
+    fun getTodayViewedIds(): List<Int> {
+        return viewedData.interviewIds.toList()
+    }
+
+    fun setDate(date: String) {
+        today = date
+    }
+
+    private fun refreshIfDateChanged() {
+        if (viewedData.date != today) {
+            viewedData = InterviewViewEntity(today, mutableSetOf())
+        }
+    }
+}

--- a/app/src/test/java/com/lottomate/lottomate/manager/InterviewViewManagerTest.kt
+++ b/app/src/test/java/com/lottomate/lottomate/manager/InterviewViewManagerTest.kt
@@ -1,0 +1,73 @@
+package com.lottomate.lottomate.manager
+
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert
+import org.junit.Before
+import org.junit.Test
+
+class InterviewViewManagerTest {
+    private lateinit var manager: FakeInterviewViewManager
+
+    @Before
+    fun setUp() {
+        manager = FakeInterviewViewManager()
+    }
+
+    @Test
+    fun `다른 날짜가 되면 초기화되어야 한다`() = runTest {
+        manager.addInterviewId(5)
+        manager.setDate("2025-05-05")
+
+        // When : 다른 날짜가 되면
+        val result = manager.getTodayViewedIds()
+
+        // Then : 초기화되어야 한다
+        Assert.assertTrue(result.isEmpty())
+    }
+
+    @Test
+    fun `최신 인터뷰를 기준으로 보지않은 인터뷰 Id 5개를 반환해야 한다`() = runTest {
+        listOf(1, 5, 7).forEach {
+            manager.addInterviewId(it)
+        }
+
+        val result = manager.getUnviewedInterviewIds(10)
+
+        Assert.assertEquals(listOf(10, 9, 8, 6, 4), result)
+    }
+
+    @Test
+    fun `모든 인터뷰를 보았을 경우, 최신 인터뷰 5개를 반환해야 한다`() = runTest {
+        (1..10).forEach { manager.addInterviewId(it) }
+
+        val result = manager.getUnviewedInterviewIds(10)
+
+        Assert.assertEquals(listOf(10, 9, 8, 7, 6), result)
+    }
+
+    @Test
+    fun `조회 가능한 인터뷰가 5개 미만일 경우 조회 가능한 인터뷰를 반환해야 한다`() = runTest {
+        (1..3).forEach { manager.addInterviewId(it) }
+
+        val result = manager.getUnviewedInterviewIds(5)
+
+        Assert.assertEquals(listOf(5, 4), result)
+    }
+
+    @Test
+    fun `인터뷰를 조회하지 않았을 경우 최신 인터뷰 5개를 반환해야 한다`() = runTest {
+        val result = manager.getUnviewedInterviewIds(10)
+
+        Assert.assertEquals(listOf(10, 9, 8, 7, 6), result)
+    }
+
+    @Test
+    fun `날짜가 변경되어 초기화된 직후에도 최신 인터뷰 5개를 반환해야 한다`() = runTest {
+        manager.addInterviewId(8)
+        manager.setDate("2025-06-10")
+
+        val result = manager.getUnviewedInterviewIds(10)
+
+        Assert.assertEquals(listOf(10, 9, 8, 7, 6), result)
+    }
+}


### PR DESCRIPTION
## 💡 ISSUE
- 

</br>

## 📝 작업 내용
- 당첨 후기(인터뷰) 노출 로직 개발
- 인터뷰 상세 화면
  - 수정된 UI 반영
- 홈/인터뷰/라운지의 인터뷰 목록 
  - 수정된 UI 반영
- 웹뷰로 당첨 후기 원문 링크 연결

</br>

## 📸 ScreenShot (Optional)
|`인터뷰 선택 시, 목록에서 선택된 인터뷰는 제외`|`인터뷰를 모두 조회했다면, 로직 초기화`|
|:--:|:--:|
|<img src="https://github.com/user-attachments/assets/5aab388d-6898-4033-80a8-599220555d1d">|<img src="https://github.com/user-attachments/assets/c4d99c61-b169-4910-815a-4dc94bb0978b">|